### PR TITLE
fix: support three-part TrueNAS version strings (25.10+)

### DIFF
--- a/version.go
+++ b/version.go
@@ -26,11 +26,11 @@ type Version struct {
 	Raw    string
 }
 
-// versionRegex extracts version numbers from strings like "TrueNAS-SCALE-24.10.2.4"
-var versionRegex = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)\.(\d+)`)
+// versionRegex extracts version numbers from strings like "TrueNAS-SCALE-24.10.2.4" or "TrueNAS-25.10.1"
+var versionRegex = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?`)
 
 // ParseVersion parses a TrueNAS version string.
-// Examples: "TrueNAS-SCALE-24.10.2.4", "TrueNAS-25.04.2.4"
+// Examples: "TrueNAS-SCALE-24.10.2.4", "TrueNAS-25.04.2.4", "TrueNAS-25.10.1"
 func ParseVersion(raw string) (Version, error) {
 	v := Version{Raw: raw}
 
@@ -63,9 +63,11 @@ func ParseVersion(raw string) (Version, error) {
 	if err != nil {
 		return v, fmt.Errorf("invalid patch version: %w", err)
 	}
-	v.Build, err = strconv.Atoi(match[4])
-	if err != nil {
-		return v, fmt.Errorf("invalid build version: %w", err)
+	if match[4] != "" {
+		v.Build, err = strconv.Atoi(match[4])
+		if err != nil {
+			return v, fmt.Errorf("invalid build version: %w", err)
+		}
 	}
 
 	return v, nil

--- a/version_test.go
+++ b/version_test.go
@@ -60,6 +60,18 @@ func TestParseVersion(t *testing.T) {
 			},
 		},
 		{
+			name: "TrueNAS 25.10 three-part version",
+			raw:  "TrueNAS-25.10.1",
+			want: Version{
+				Major:  25,
+				Minor:  10,
+				Patch:  1,
+				Build:  0,
+				Flavor: FlavorUnknown,
+				Raw:    "TrueNAS-25.10.1",
+			},
+		},
+		{
 			name:    "invalid version string",
 			raw:     "not-a-version",
 			wantErr: true,


### PR DESCRIPTION
## Summary

- TrueNAS 25.10+ uses three-part versions (`TrueNAS-25.10.1`) instead of four-part (`TrueNAS-SCALE-24.10.2.4`). Makes the build segment optional, defaulting to 0.
- Migrated from [terraform-provider-truenas#3](https://github.com/deevus/terraform-provider-truenas/pull/3) by @f33rx

Closes #4

## Test plan

- [x] Existing four-part version tests still pass
- [x] New three-part version test (`TrueNAS-25.10.1`) passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)