### PR TITLE
feat: add FastList option to CloudSyncTask

### DIFF
--- a/cloudsync_service.go
+++ b/cloudsync_service.go
@@ -37,6 +37,7 @@ type CloudSyncTask struct {
 	BWLimit            []BwLimit
 	FollowSymlinks     bool
 	CreateEmptySrcDirs bool
+	FastList           bool
 	Enabled            bool
 	Encryption         bool
 	EncryptionPassword string
@@ -59,6 +60,7 @@ type CreateCloudSyncTaskOpts struct {
 	BWLimit            []BwLimit
 	FollowSymlinks     bool
 	CreateEmptySrcDirs bool
+	FastList           bool
 	Enabled            bool
 	Encryption         bool
 	EncryptionPassword string
@@ -305,9 +307,12 @@ func taskOptsToParams(opts CreateCloudSyncTaskOpts) map[string]any {
 		},
 	}
 
-	if opts.Attributes != nil {
-		params["attributes"] = opts.Attributes
+	attrs := opts.Attributes
+	if attrs == nil {
+		attrs = map[string]any{}
 	}
+	attrs["fast_list"] = opts.FastList
+	params["attributes"] = attrs
 
 	if opts.Encryption {
 		params["encryption_password"] = opts.EncryptionPassword
@@ -362,6 +367,10 @@ func taskFromResponse(resp CloudSyncTaskResponse) CloudSyncTask {
 	if len(resp.Attributes) > 0 {
 		var attrs map[string]any
 		if err := json.Unmarshal(resp.Attributes, &attrs); err == nil {
+			if fl, ok := attrs["fast_list"].(bool); ok {
+				task.FastList = fl
+				delete(attrs, "fast_list")
+			}
 			task.Attributes = attrs
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `FastList` bool field to `CloudSyncTask` and `CreateCloudSyncTaskOpts`
- `fast_list` is stored inside the `attributes` JSON object in the TrueNAS API, so `taskOptsToParams()` injects it into attributes on write and `taskFromResponse()` extracts it on read
- Original work by @mircea-pavel-anton in [terraform-provider-truenas#8](https://github.com/deevus/terraform-provider-truenas/pull/8)

Closes #8

## Test plan

- [x] `TestTaskOptsToParams_FastList` — fast_list=true appears in attributes
- [x] `TestTaskOptsToParams_FastList_MergesWithExistingAttributes` — merges with existing bucket attrs
- [x] `TestTaskOptsToParams_NoOptionalFields` — fast_list=false still sent in attributes when Attributes is nil
- [x] `TestTaskFromResponse_FastList` — extracted from attributes, removed from map
- [x] `TestTaskFromResponse_FastListFalse` — defaults to false when absent
- [x] Full suite passes with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)