### PR TITLE
feat: add UserService and GroupService

### DIFF
--- a/group.go
+++ b/group.go
@@ -1,0 +1,15 @@
+package truenas
+
+// GroupResponse represents a group from the TrueNAS API.
+type GroupResponse struct {
+	ID                   int64    `json:"id"`
+	GID                  int64    `json:"gid"`
+	Name                 string   `json:"group"`
+	Builtin              bool     `json:"builtin"`
+	SMB                  bool     `json:"smb"`
+	SudoCommands         []string `json:"sudo_commands"`
+	SudoCommandsNopasswd []string `json:"sudo_commands_nopasswd"`
+	Users                []int64  `json:"users"`
+	Local                bool     `json:"local"`
+	Immutable            bool     `json:"immutable"`
+}

--- a/group_service.go
+++ b/group_service.go
@@ -1,0 +1,200 @@
+package truenas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Group is the user-facing representation of a TrueNAS group.
+type Group struct {
+	ID                   int64
+	GID                  int64
+	Name                 string
+	Builtin              bool
+	SMB                  bool
+	SudoCommands         []string
+	SudoCommandsNopasswd []string
+	Users                []int64
+	Local                bool
+	Immutable            bool
+}
+
+// CreateGroupOpts contains options for creating a group.
+type CreateGroupOpts struct {
+	Name                 string
+	GID                  int64
+	SMB                  bool
+	SudoCommands         []string
+	SudoCommandsNopasswd []string
+}
+
+// UpdateGroupOpts contains options for updating a group.
+type UpdateGroupOpts struct {
+	Name                 string
+	SMB                  bool
+	SudoCommands         []string
+	SudoCommandsNopasswd []string
+}
+
+// GroupService provides typed methods for the group.* API namespace.
+type GroupService struct {
+	client  Caller
+	version Version
+}
+
+// NewGroupService creates a new GroupService.
+func NewGroupService(c Caller, v Version) *GroupService {
+	return &GroupService{client: c, version: v}
+}
+
+// Create creates a group and returns the full object.
+func (s *GroupService) Create(ctx context.Context, opts CreateGroupOpts) (*Group, error) {
+	params := createGroupParams(opts)
+	result, err := s.client.Call(ctx, "group.create", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var id int64
+	if err := json.Unmarshal(result, &id); err != nil {
+		return nil, fmt.Errorf("parse create response: %w", err)
+	}
+
+	return s.Get(ctx, id)
+}
+
+// Get returns a group by ID, or nil if not found.
+func (s *GroupService) Get(ctx context.Context, id int64) (*Group, error) {
+	result, err := s.client.Call(ctx, "group.get_instance", id)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var resp GroupResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return nil, fmt.Errorf("parse get_instance response: %w", err)
+	}
+
+	group := groupFromResponse(resp)
+	return &group, nil
+}
+
+// GetByName returns a group by name, or nil if not found.
+func (s *GroupService) GetByName(ctx context.Context, name string) (*Group, error) {
+	filter := [][]any{{"group", "=", name}}
+	return s.queryOne(ctx, filter)
+}
+
+// GetByGID returns a group by GID, or nil if not found.
+func (s *GroupService) GetByGID(ctx context.Context, gid int64) (*Group, error) {
+	filter := [][]any{{"gid", "=", gid}}
+	return s.queryOne(ctx, filter)
+}
+
+// List returns all groups.
+func (s *GroupService) List(ctx context.Context) ([]Group, error) {
+	result, err := s.client.Call(ctx, "group.query", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responses []GroupResponse
+	if err := json.Unmarshal(result, &responses); err != nil {
+		return nil, fmt.Errorf("parse query response: %w", err)
+	}
+
+	groups := make([]Group, len(responses))
+	for i, resp := range responses {
+		groups[i] = groupFromResponse(resp)
+	}
+	return groups, nil
+}
+
+// Update updates a group and returns the full object.
+func (s *GroupService) Update(ctx context.Context, id int64, opts UpdateGroupOpts) (*Group, error) {
+	params := updateGroupParams(opts)
+	_, err := s.client.Call(ctx, "group.update", []any{id, params})
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Get(ctx, id)
+}
+
+// Delete deletes a group by ID.
+func (s *GroupService) Delete(ctx context.Context, id int64) error {
+	_, err := s.client.Call(ctx, "group.delete", []any{id, map[string]any{"delete_users": false}})
+	return err
+}
+
+func (s *GroupService) queryOne(ctx context.Context, filter [][]any) (*Group, error) {
+	result, err := s.client.Call(ctx, "group.query", filter)
+	if err != nil {
+		return nil, err
+	}
+
+	var responses []GroupResponse
+	if err := json.Unmarshal(result, &responses); err != nil {
+		return nil, fmt.Errorf("parse query response: %w", err)
+	}
+
+	if len(responses) == 0 {
+		return nil, nil
+	}
+
+	group := groupFromResponse(responses[0])
+	return &group, nil
+}
+
+// createGroupParams converts CreateGroupOpts to API parameters.
+func createGroupParams(opts CreateGroupOpts) map[string]any {
+	params := map[string]any{
+		"name": opts.Name,
+		"smb":  opts.SMB,
+	}
+	if opts.GID != 0 {
+		params["gid"] = opts.GID
+	}
+	if opts.SudoCommands != nil {
+		params["sudo_commands"] = opts.SudoCommands
+	}
+	if opts.SudoCommandsNopasswd != nil {
+		params["sudo_commands_nopasswd"] = opts.SudoCommandsNopasswd
+	}
+	return params
+}
+
+// updateGroupParams converts UpdateGroupOpts to API parameters.
+func updateGroupParams(opts UpdateGroupOpts) map[string]any {
+	params := map[string]any{
+		"name": opts.Name,
+		"smb":  opts.SMB,
+	}
+	if opts.SudoCommands != nil {
+		params["sudo_commands"] = opts.SudoCommands
+	}
+	if opts.SudoCommandsNopasswd != nil {
+		params["sudo_commands_nopasswd"] = opts.SudoCommandsNopasswd
+	}
+	return params
+}
+
+// groupFromResponse converts a wire-format GroupResponse to a user-facing Group.
+func groupFromResponse(resp GroupResponse) Group {
+	return Group{
+		ID:                   resp.ID,
+		GID:                  resp.GID,
+		Name:                 resp.Name,
+		Builtin:              resp.Builtin,
+		SMB:                  resp.SMB,
+		SudoCommands:         resp.SudoCommands,
+		SudoCommandsNopasswd: resp.SudoCommandsNopasswd,
+		Users:                resp.Users,
+		Local:                resp.Local,
+		Immutable:            resp.Immutable,
+	}
+}

--- a/group_service_iface.go
+++ b/group_service_iface.go
@@ -1,0 +1,78 @@
+package truenas
+
+import "context"
+
+// GroupServiceAPI defines the interface for group operations.
+type GroupServiceAPI interface {
+	Create(ctx context.Context, opts CreateGroupOpts) (*Group, error)
+	Get(ctx context.Context, id int64) (*Group, error)
+	GetByName(ctx context.Context, name string) (*Group, error)
+	GetByGID(ctx context.Context, gid int64) (*Group, error)
+	List(ctx context.Context) ([]Group, error)
+	Update(ctx context.Context, id int64, opts UpdateGroupOpts) (*Group, error)
+	Delete(ctx context.Context, id int64) error
+}
+
+// Compile-time checks.
+var _ GroupServiceAPI = (*GroupService)(nil)
+var _ GroupServiceAPI = (*MockGroupService)(nil)
+
+// MockGroupService is a test double for GroupServiceAPI.
+type MockGroupService struct {
+	CreateFunc    func(ctx context.Context, opts CreateGroupOpts) (*Group, error)
+	GetFunc       func(ctx context.Context, id int64) (*Group, error)
+	GetByNameFunc func(ctx context.Context, name string) (*Group, error)
+	GetByGIDFunc  func(ctx context.Context, gid int64) (*Group, error)
+	ListFunc      func(ctx context.Context) ([]Group, error)
+	UpdateFunc    func(ctx context.Context, id int64, opts UpdateGroupOpts) (*Group, error)
+	DeleteFunc    func(ctx context.Context, id int64) error
+}
+
+func (m *MockGroupService) Create(ctx context.Context, opts CreateGroupOpts) (*Group, error) {
+	if m.CreateFunc != nil {
+		return m.CreateFunc(ctx, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockGroupService) Get(ctx context.Context, id int64) (*Group, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *MockGroupService) GetByName(ctx context.Context, name string) (*Group, error) {
+	if m.GetByNameFunc != nil {
+		return m.GetByNameFunc(ctx, name)
+	}
+	return nil, nil
+}
+
+func (m *MockGroupService) GetByGID(ctx context.Context, gid int64) (*Group, error) {
+	if m.GetByGIDFunc != nil {
+		return m.GetByGIDFunc(ctx, gid)
+	}
+	return nil, nil
+}
+
+func (m *MockGroupService) List(ctx context.Context) ([]Group, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *MockGroupService) Update(ctx context.Context, id int64, opts UpdateGroupOpts) (*Group, error) {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(ctx, id, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockGroupService) Delete(ctx context.Context, id int64) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	return nil
+}

--- a/group_service_iface_test.go
+++ b/group_service_iface_test.go
@@ -1,0 +1,45 @@
+package truenas
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMockGroupService_ImplementsInterface(t *testing.T) {
+	var _ GroupServiceAPI = (*GroupService)(nil)
+	var _ GroupServiceAPI = (*MockGroupService)(nil)
+}
+
+func TestMockGroupService_DefaultsToNil(t *testing.T) {
+	mock := &MockGroupService{}
+	ctx := context.Background()
+
+	group, err := mock.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if group != nil {
+		t.Fatalf("expected nil result, got: %v", group)
+	}
+}
+
+func TestMockGroupService_CallsFunc(t *testing.T) {
+	called := false
+	mock := &MockGroupService{
+		GetFunc: func(ctx context.Context, id int64) (*Group, error) {
+			called = true
+			return &Group{ID: id}, nil
+		},
+	}
+
+	group, err := mock.Get(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected GetFunc to be called")
+	}
+	if group.ID != 42 {
+		t.Fatalf("expected ID 42, got %d", group.ID)
+	}
+}

--- a/group_service_test.go
+++ b/group_service_test.go
@@ -1,0 +1,497 @@
+package truenas
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// --- Conversion tests ---
+
+func TestGroupFromResponse(t *testing.T) {
+	resp := GroupResponse{
+		ID:                   10,
+		GID:                  1000,
+		Name:                 "developers",
+		Builtin:              false,
+		SMB:                  true,
+		SudoCommands:         []string{"ALL"},
+		SudoCommandsNopasswd: []string{"/usr/bin/apt"},
+		Users:                []int64{1, 2, 3},
+		Local:                true,
+		Immutable:            false,
+	}
+
+	group := groupFromResponse(resp)
+
+	if group.ID != 10 {
+		t.Errorf("expected ID 10, got %d", group.ID)
+	}
+	if group.GID != 1000 {
+		t.Errorf("expected GID 1000, got %d", group.GID)
+	}
+	if group.Name != "developers" {
+		t.Errorf("expected name developers, got %s", group.Name)
+	}
+	if group.Builtin {
+		t.Error("expected Builtin=false")
+	}
+	if !group.SMB {
+		t.Error("expected SMB=true")
+	}
+	if len(group.SudoCommands) != 1 || group.SudoCommands[0] != "ALL" {
+		t.Errorf("expected SudoCommands=[ALL], got %v", group.SudoCommands)
+	}
+	if len(group.SudoCommandsNopasswd) != 1 || group.SudoCommandsNopasswd[0] != "/usr/bin/apt" {
+		t.Errorf("expected SudoCommandsNopasswd=[/usr/bin/apt], got %v", group.SudoCommandsNopasswd)
+	}
+	if len(group.Users) != 3 {
+		t.Errorf("expected 3 users, got %d", len(group.Users))
+	}
+	if !group.Local {
+		t.Error("expected Local=true")
+	}
+	if group.Immutable {
+		t.Error("expected Immutable=false")
+	}
+}
+
+func TestGroupFromResponse_NilSlices(t *testing.T) {
+	resp := GroupResponse{
+		ID:   1,
+		GID:  500,
+		Name: "empty",
+	}
+
+	group := groupFromResponse(resp)
+
+	if group.SudoCommands != nil {
+		t.Errorf("expected nil SudoCommands, got %v", group.SudoCommands)
+	}
+	if group.SudoCommandsNopasswd != nil {
+		t.Errorf("expected nil SudoCommandsNopasswd, got %v", group.SudoCommandsNopasswd)
+	}
+	if group.Users != nil {
+		t.Errorf("expected nil Users, got %v", group.Users)
+	}
+}
+
+func TestCreateGroupParams(t *testing.T) {
+	opts := CreateGroupOpts{
+		Name:                 "devs",
+		GID:                  5000,
+		SMB:                  true,
+		SudoCommands:         []string{"ALL"},
+		SudoCommandsNopasswd: []string{"/usr/bin/apt"},
+	}
+
+	params := createGroupParams(opts)
+
+	if params["name"] != "devs" {
+		t.Errorf("expected name devs, got %v", params["name"])
+	}
+	if params["gid"] != int64(5000) {
+		t.Errorf("expected gid 5000, got %v", params["gid"])
+	}
+	if params["smb"] != true {
+		t.Errorf("expected smb true, got %v", params["smb"])
+	}
+	if sc, ok := params["sudo_commands"].([]string); !ok || len(sc) != 1 {
+		t.Errorf("expected sudo_commands [ALL], got %v", params["sudo_commands"])
+	}
+	if sc, ok := params["sudo_commands_nopasswd"].([]string); !ok || len(sc) != 1 {
+		t.Errorf("expected sudo_commands_nopasswd [/usr/bin/apt], got %v", params["sudo_commands_nopasswd"])
+	}
+}
+
+func TestCreateGroupParams_NoGID(t *testing.T) {
+	opts := CreateGroupOpts{
+		Name: "auto-gid",
+		SMB:  false,
+	}
+
+	params := createGroupParams(opts)
+
+	if _, ok := params["gid"]; ok {
+		t.Error("expected no gid when GID is 0")
+	}
+	if params["smb"] != false {
+		t.Errorf("expected smb false, got %v", params["smb"])
+	}
+}
+
+func TestCreateGroupParams_NoSudo(t *testing.T) {
+	opts := CreateGroupOpts{
+		Name: "no-sudo",
+	}
+
+	params := createGroupParams(opts)
+
+	if _, ok := params["sudo_commands"]; ok {
+		t.Error("expected no sudo_commands when nil")
+	}
+	if _, ok := params["sudo_commands_nopasswd"]; ok {
+		t.Error("expected no sudo_commands_nopasswd when nil")
+	}
+}
+
+func TestUpdateGroupParams(t *testing.T) {
+	opts := UpdateGroupOpts{
+		Name: "renamed",
+		SMB:  true,
+	}
+
+	params := updateGroupParams(opts)
+
+	if params["name"] != "renamed" {
+		t.Errorf("expected name renamed, got %v", params["name"])
+	}
+	if params["smb"] != true {
+		t.Errorf("expected smb true, got %v", params["smb"])
+	}
+	// GID must never be included in update
+	if _, ok := params["gid"]; ok {
+		t.Error("expected no gid in update params")
+	}
+}
+
+// --- CRUD tests ---
+
+func TestGroupService_Create(t *testing.T) {
+	mock := &mockCaller{}
+	callCount := 0
+	mock.callFunc = func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+		callCount++
+		switch method {
+		case "group.create":
+			p := params.(map[string]any)
+			if p["name"] != "devs" {
+				t.Errorf("expected name devs, got %v", p["name"])
+			}
+			return json.RawMessage(`10`), nil
+		case "group.get_instance":
+			return json.RawMessage(`{"id":10,"gid":5000,"group":"devs","smb":true,"builtin":false,"local":true,"immutable":false}`), nil
+		default:
+			t.Errorf("unexpected method: %s", method)
+			return nil, nil
+		}
+	}
+
+	svc := NewGroupService(mock, Version{})
+	group, err := svc.Create(context.Background(), CreateGroupOpts{
+		Name: "devs",
+		GID:  5000,
+		SMB:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if group == nil {
+		t.Fatal("expected non-nil group")
+	}
+	if group.ID != 10 {
+		t.Errorf("expected ID 10, got %d", group.ID)
+	}
+	if group.Name != "devs" {
+		t.Errorf("expected name devs, got %s", group.Name)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (create + get_instance), got %d", callCount)
+	}
+}
+
+func TestGroupService_Create_Error(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return nil, errors.New("permission denied")
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	group, err := svc.Create(context.Background(), CreateGroupOpts{Name: "fail"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if group != nil {
+		t.Error("expected nil group on error")
+	}
+}
+
+func TestGroupService_Get(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "group.get_instance" {
+				t.Errorf("expected method group.get_instance, got %s", method)
+			}
+			id, ok := params.(int64)
+			if !ok || id != 10 {
+				t.Errorf("expected id 10, got %v", params)
+			}
+			return json.RawMessage(`{"id":10,"gid":1000,"group":"wheel","smb":false,"builtin":true,"local":true,"immutable":true}`), nil
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	group, err := svc.Get(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if group == nil {
+		t.Fatal("expected non-nil group")
+	}
+	if group.Name != "wheel" {
+		t.Errorf("expected name wheel, got %s", group.Name)
+	}
+	if !group.Builtin {
+		t.Error("expected Builtin=true")
+	}
+}
+
+func TestGroupService_Get_NotFound(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return nil, errors.New("group 999 does not exist")
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	group, err := svc.Get(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("expected nil error for not-found, got: %v", err)
+	}
+	if group != nil {
+		t.Error("expected nil group for not-found")
+	}
+}
+
+func TestGroupService_GetByName(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "group.query" {
+				t.Errorf("expected method group.query, got %s", method)
+			}
+			filter, ok := params.([][]any)
+			if !ok {
+				t.Fatal("expected [][]any params")
+			}
+			if len(filter) != 1 || filter[0][0] != "group" || filter[0][1] != "=" || filter[0][2] != "wheel" {
+				t.Errorf("unexpected filter: %v", filter)
+			}
+			return json.RawMessage(`[{"id":10,"gid":0,"group":"wheel","smb":false,"builtin":true,"local":true,"immutable":true}]`), nil
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	group, err := svc.GetByName(context.Background(), "wheel")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if group == nil {
+		t.Fatal("expected non-nil group")
+	}
+	if group.Name != "wheel" {
+		t.Errorf("expected name wheel, got %s", group.Name)
+	}
+}
+
+func TestGroupService_GetByName_NotFound(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return json.RawMessage(`[]`), nil
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	group, err := svc.GetByName(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if group != nil {
+		t.Error("expected nil group for not-found")
+	}
+}
+
+func TestGroupService_GetByGID(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "group.query" {
+				t.Errorf("expected method group.query, got %s", method)
+			}
+			filter := params.([][]any)
+			if filter[0][0] != "gid" || filter[0][2] != int64(1000) {
+				t.Errorf("unexpected filter: %v", filter)
+			}
+			return json.RawMessage(`[{"id":5,"gid":1000,"group":"staff","smb":true,"builtin":false,"local":true,"immutable":false}]`), nil
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	group, err := svc.GetByGID(context.Background(), 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if group == nil {
+		t.Fatal("expected non-nil group")
+	}
+	if group.GID != 1000 {
+		t.Errorf("expected GID 1000, got %d", group.GID)
+	}
+}
+
+func TestGroupService_List(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "group.query" {
+				t.Errorf("expected method group.query, got %s", method)
+			}
+			if params != nil {
+				t.Error("expected nil params for List")
+			}
+			return json.RawMessage(`[
+				{"id":1,"gid":0,"group":"wheel","builtin":true,"smb":false,"local":true,"immutable":true},
+				{"id":2,"gid":1000,"group":"devs","builtin":false,"smb":true,"local":true,"immutable":false}
+			]`), nil
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	groups, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].Name != "wheel" {
+		t.Errorf("expected first group wheel, got %s", groups[0].Name)
+	}
+	if groups[1].Name != "devs" {
+		t.Errorf("expected second group devs, got %s", groups[1].Name)
+	}
+}
+
+func TestGroupService_List_Empty(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return json.RawMessage(`[]`), nil
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	groups, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups) != 0 {
+		t.Errorf("expected 0 groups, got %d", len(groups))
+	}
+}
+
+func TestGroupService_Update(t *testing.T) {
+	mock := &mockCaller{}
+	callCount := 0
+	mock.callFunc = func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+		callCount++
+		switch method {
+		case "group.update":
+			slice := params.([]any)
+			if slice[0] != int64(10) {
+				t.Errorf("expected id 10, got %v", slice[0])
+			}
+			p := slice[1].(map[string]any)
+			if p["name"] != "renamed" {
+				t.Errorf("expected name renamed, got %v", p["name"])
+			}
+			return nil, nil
+		case "group.get_instance":
+			return json.RawMessage(`{"id":10,"gid":1000,"group":"renamed","smb":true,"builtin":false,"local":true,"immutable":false}`), nil
+		default:
+			t.Errorf("unexpected method: %s", method)
+			return nil, nil
+		}
+	}
+
+	svc := NewGroupService(mock, Version{})
+	group, err := svc.Update(context.Background(), 10, UpdateGroupOpts{
+		Name: "renamed",
+		SMB:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if group == nil {
+		t.Fatal("expected non-nil group")
+	}
+	if group.Name != "renamed" {
+		t.Errorf("expected name renamed, got %s", group.Name)
+	}
+}
+
+func TestGroupService_Update_Error(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return nil, errors.New("not found")
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	_, err := svc.Update(context.Background(), 999, UpdateGroupOpts{Name: "fail"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGroupService_Delete(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "group.delete" {
+				t.Errorf("expected method group.delete, got %s", method)
+			}
+			slice := params.([]any)
+			if slice[0] != int64(10) {
+				t.Errorf("expected id 10, got %v", slice[0])
+			}
+			opts := slice[1].(map[string]any)
+			if opts["delete_users"] != false {
+				t.Errorf("expected delete_users=false, got %v", opts["delete_users"])
+			}
+			return nil, nil
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	err := svc.Delete(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGroupService_Delete_Error(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return nil, errors.New("permission denied")
+		},
+	}
+
+	svc := NewGroupService(mock, Version{})
+	err := svc.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNewGroupService(t *testing.T) {
+	mock := &mockCaller{}
+	v := Version{Major: 25, Minor: 4}
+	svc := NewGroupService(mock, v)
+	if svc == nil {
+		t.Fatal("expected non-nil service")
+	}
+	if svc.client != mock {
+		t.Error("expected client to be set")
+	}
+	if svc.version != v {
+		t.Error("expected version to be set")
+	}
+}

--- a/user.go
+++ b/user.go
@@ -1,0 +1,32 @@
+package truenas
+
+// UserResponse represents a user from the TrueNAS API.
+type UserResponse struct {
+	ID                   int64             `json:"id"`
+	UID                  int64             `json:"uid"`
+	Username             string            `json:"username"`
+	FullName             string            `json:"full_name"`
+	Email                *string           `json:"email"`
+	Home                 string            `json:"home"`
+	Shell                string            `json:"shell"`
+	HomeMode             string            `json:"home_mode"`
+	Group                UserGroupResponse `json:"group"`
+	Groups               []int64           `json:"groups"`
+	SMB                  bool              `json:"smb"`
+	PasswordDisabled     bool              `json:"password_disabled"`
+	SSHPasswordEnabled   bool              `json:"ssh_password_enabled"`
+	SSHPubKey            *string           `json:"sshpubkey"`
+	Locked               bool              `json:"locked"`
+	SudoCommands         []string          `json:"sudo_commands"`
+	SudoCommandsNopasswd []string          `json:"sudo_commands_nopasswd"`
+	Builtin              bool              `json:"builtin"`
+	Local                bool              `json:"local"`
+	Immutable            bool              `json:"immutable"`
+}
+
+// UserGroupResponse represents a user's primary group from the API.
+type UserGroupResponse struct {
+	ID        int64  `json:"id"`
+	GID       int64  `json:"bsdgrp_gid"`
+	GroupName string `json:"bsdgrp_group"`
+}

--- a/user_service.go
+++ b/user_service.go
@@ -1,0 +1,303 @@
+package truenas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// User is the user-facing representation of a TrueNAS user.
+type User struct {
+	ID                   int64
+	UID                  int64
+	Username             string
+	FullName             string
+	Email                string
+	Home                 string
+	Shell                string
+	HomeMode             string
+	GroupID              int64
+	Groups               []int64
+	SMB                  bool
+	PasswordDisabled     bool
+	SSHPasswordEnabled   bool
+	SSHPubKey            string
+	Locked               bool
+	SudoCommands         []string
+	SudoCommandsNopasswd []string
+	Builtin              bool
+	Local                bool
+	Immutable            bool
+}
+
+// CreateUserOpts contains options for creating a user.
+type CreateUserOpts struct {
+	Username             string
+	FullName             string
+	Email                string
+	UID                  int64
+	Password             string
+	PasswordDisabled     bool
+	Group                int64
+	GroupCreate          bool
+	Groups               []int64
+	Home                 string
+	HomeCreate           bool
+	HomeMode             string
+	Shell                string
+	SMB                  bool
+	SSHPasswordEnabled   bool
+	SSHPubKey            string
+	Locked               bool
+	SudoCommands         []string
+	SudoCommandsNopasswd []string
+}
+
+// UpdateUserOpts contains options for updating a user.
+// UID, GroupCreate, and HomeCreate are immutable after creation.
+type UpdateUserOpts struct {
+	Username             string
+	FullName             string
+	Email                string
+	Password             string
+	PasswordDisabled     bool
+	Group                int64
+	Groups               []int64
+	Home                 string
+	HomeMode             string
+	Shell                string
+	SMB                  bool
+	SSHPasswordEnabled   bool
+	SSHPubKey            string
+	Locked               bool
+	SudoCommands         []string
+	SudoCommandsNopasswd []string
+}
+
+// UserService provides typed methods for the user.* API namespace.
+type UserService struct {
+	client  Caller
+	version Version
+}
+
+// NewUserService creates a new UserService.
+func NewUserService(c Caller, v Version) *UserService {
+	return &UserService{client: c, version: v}
+}
+
+// Create creates a user and returns the full object.
+func (s *UserService) Create(ctx context.Context, opts CreateUserOpts) (*User, error) {
+	params := createUserParams(opts)
+	result, err := s.client.Call(ctx, "user.create", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var createResp struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(result, &createResp); err != nil {
+		return nil, fmt.Errorf("parse create response: %w", err)
+	}
+
+	return s.Get(ctx, createResp.ID)
+}
+
+// Get returns a user by ID, or nil if not found.
+func (s *UserService) Get(ctx context.Context, id int64) (*User, error) {
+	result, err := s.client.Call(ctx, "user.get_instance", id)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var resp UserResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return nil, fmt.Errorf("parse get_instance response: %w", err)
+	}
+
+	user := userFromResponse(resp)
+	return &user, nil
+}
+
+// GetByUsername returns a user by username, or nil if not found.
+func (s *UserService) GetByUsername(ctx context.Context, username string) (*User, error) {
+	filter := [][]any{{"username", "=", username}}
+	return s.queryOne(ctx, filter)
+}
+
+// GetByUID returns a user by UID, or nil if not found.
+func (s *UserService) GetByUID(ctx context.Context, uid int64) (*User, error) {
+	filter := [][]any{{"uid", "=", uid}}
+	return s.queryOne(ctx, filter)
+}
+
+// List returns all users.
+func (s *UserService) List(ctx context.Context) ([]User, error) {
+	result, err := s.client.Call(ctx, "user.query", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var responses []UserResponse
+	if err := json.Unmarshal(result, &responses); err != nil {
+		return nil, fmt.Errorf("parse query response: %w", err)
+	}
+
+	users := make([]User, len(responses))
+	for i, resp := range responses {
+		users[i] = userFromResponse(resp)
+	}
+	return users, nil
+}
+
+// Update updates a user and returns the full object.
+func (s *UserService) Update(ctx context.Context, id int64, opts UpdateUserOpts) (*User, error) {
+	params := updateUserParams(opts)
+	_, err := s.client.Call(ctx, "user.update", []any{id, params})
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Get(ctx, id)
+}
+
+// Delete deletes a user by ID.
+func (s *UserService) Delete(ctx context.Context, id int64) error {
+	_, err := s.client.Call(ctx, "user.delete", []any{id, map[string]any{"delete_group": true}})
+	return err
+}
+
+func (s *UserService) queryOne(ctx context.Context, filter [][]any) (*User, error) {
+	result, err := s.client.Call(ctx, "user.query", filter)
+	if err != nil {
+		return nil, err
+	}
+
+	var responses []UserResponse
+	if err := json.Unmarshal(result, &responses); err != nil {
+		return nil, fmt.Errorf("parse query response: %w", err)
+	}
+
+	if len(responses) == 0 {
+		return nil, nil
+	}
+
+	user := userFromResponse(responses[0])
+	return &user, nil
+}
+
+// createUserParams converts CreateUserOpts to API parameters.
+func createUserParams(opts CreateUserOpts) map[string]any {
+	params := map[string]any{
+		"username":             opts.Username,
+		"full_name":            opts.FullName,
+		"email":                opts.Email,
+		"password_disabled":    opts.PasswordDisabled,
+		"home":                 opts.Home,
+		"home_mode":            opts.HomeMode,
+		"shell":                opts.Shell,
+		"smb":                  opts.SMB,
+		"ssh_password_enabled": opts.SSHPasswordEnabled,
+		"locked":               opts.Locked,
+		"group_create":         opts.GroupCreate,
+	}
+	if opts.UID != 0 {
+		params["uid"] = opts.UID
+	}
+	if opts.Password != "" {
+		params["password"] = opts.Password
+	}
+	if opts.Group != 0 {
+		params["group"] = opts.Group
+	}
+	if opts.Groups != nil {
+		params["groups"] = opts.Groups
+	}
+	if opts.HomeCreate {
+		params["home_create"] = opts.HomeCreate
+	}
+	if opts.SSHPubKey != "" {
+		params["sshpubkey"] = opts.SSHPubKey
+	}
+	if opts.SudoCommands != nil {
+		params["sudo_commands"] = opts.SudoCommands
+	}
+	if opts.SudoCommandsNopasswd != nil {
+		params["sudo_commands_nopasswd"] = opts.SudoCommandsNopasswd
+	}
+	return params
+}
+
+// updateUserParams converts UpdateUserOpts to API parameters.
+// UID, GroupCreate, and HomeCreate are never included.
+func updateUserParams(opts UpdateUserOpts) map[string]any {
+	params := map[string]any{
+		"username":             opts.Username,
+		"full_name":            opts.FullName,
+		"email":                opts.Email,
+		"password_disabled":    opts.PasswordDisabled,
+		"home":                 opts.Home,
+		"home_mode":            opts.HomeMode,
+		"shell":                opts.Shell,
+		"smb":                  opts.SMB,
+		"ssh_password_enabled": opts.SSHPasswordEnabled,
+		"locked":               opts.Locked,
+	}
+	if opts.Password != "" {
+		params["password"] = opts.Password
+	}
+	if opts.Group != 0 {
+		params["group"] = opts.Group
+	}
+	if opts.Groups != nil {
+		params["groups"] = opts.Groups
+	}
+	if opts.SSHPubKey != "" {
+		params["sshpubkey"] = opts.SSHPubKey
+	}
+	if opts.SudoCommands != nil {
+		params["sudo_commands"] = opts.SudoCommands
+	}
+	if opts.SudoCommandsNopasswd != nil {
+		params["sudo_commands_nopasswd"] = opts.SudoCommandsNopasswd
+	}
+	return params
+}
+
+// userFromResponse converts a wire-format UserResponse to a user-facing User.
+func userFromResponse(resp UserResponse) User {
+	email := ""
+	if resp.Email != nil {
+		email = *resp.Email
+	}
+	sshPubKey := ""
+	if resp.SSHPubKey != nil {
+		sshPubKey = *resp.SSHPubKey
+	}
+
+	return User{
+		ID:                   resp.ID,
+		UID:                  resp.UID,
+		Username:             resp.Username,
+		FullName:             resp.FullName,
+		Email:                email,
+		Home:                 resp.Home,
+		Shell:                resp.Shell,
+		HomeMode:             resp.HomeMode,
+		GroupID:              resp.Group.ID,
+		Groups:               resp.Groups,
+		SMB:                  resp.SMB,
+		PasswordDisabled:     resp.PasswordDisabled,
+		SSHPasswordEnabled:   resp.SSHPasswordEnabled,
+		SSHPubKey:            sshPubKey,
+		Locked:               resp.Locked,
+		SudoCommands:         resp.SudoCommands,
+		SudoCommandsNopasswd: resp.SudoCommandsNopasswd,
+		Builtin:              resp.Builtin,
+		Local:                resp.Local,
+		Immutable:            resp.Immutable,
+	}
+}

--- a/user_service_iface.go
+++ b/user_service_iface.go
@@ -1,0 +1,78 @@
+package truenas
+
+import "context"
+
+// UserServiceAPI defines the interface for user operations.
+type UserServiceAPI interface {
+	Create(ctx context.Context, opts CreateUserOpts) (*User, error)
+	Get(ctx context.Context, id int64) (*User, error)
+	GetByUsername(ctx context.Context, username string) (*User, error)
+	GetByUID(ctx context.Context, uid int64) (*User, error)
+	List(ctx context.Context) ([]User, error)
+	Update(ctx context.Context, id int64, opts UpdateUserOpts) (*User, error)
+	Delete(ctx context.Context, id int64) error
+}
+
+// Compile-time checks.
+var _ UserServiceAPI = (*UserService)(nil)
+var _ UserServiceAPI = (*MockUserService)(nil)
+
+// MockUserService is a test double for UserServiceAPI.
+type MockUserService struct {
+	CreateFunc        func(ctx context.Context, opts CreateUserOpts) (*User, error)
+	GetFunc           func(ctx context.Context, id int64) (*User, error)
+	GetByUsernameFunc func(ctx context.Context, username string) (*User, error)
+	GetByUIDFunc      func(ctx context.Context, uid int64) (*User, error)
+	ListFunc          func(ctx context.Context) ([]User, error)
+	UpdateFunc        func(ctx context.Context, id int64, opts UpdateUserOpts) (*User, error)
+	DeleteFunc        func(ctx context.Context, id int64) error
+}
+
+func (m *MockUserService) Create(ctx context.Context, opts CreateUserOpts) (*User, error) {
+	if m.CreateFunc != nil {
+		return m.CreateFunc(ctx, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockUserService) Get(ctx context.Context, id int64) (*User, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *MockUserService) GetByUsername(ctx context.Context, username string) (*User, error) {
+	if m.GetByUsernameFunc != nil {
+		return m.GetByUsernameFunc(ctx, username)
+	}
+	return nil, nil
+}
+
+func (m *MockUserService) GetByUID(ctx context.Context, uid int64) (*User, error) {
+	if m.GetByUIDFunc != nil {
+		return m.GetByUIDFunc(ctx, uid)
+	}
+	return nil, nil
+}
+
+func (m *MockUserService) List(ctx context.Context) ([]User, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *MockUserService) Update(ctx context.Context, id int64, opts UpdateUserOpts) (*User, error) {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(ctx, id, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockUserService) Delete(ctx context.Context, id int64) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, id)
+	}
+	return nil
+}

--- a/user_service_iface_test.go
+++ b/user_service_iface_test.go
@@ -1,0 +1,45 @@
+package truenas
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMockUserService_ImplementsInterface(t *testing.T) {
+	var _ UserServiceAPI = (*UserService)(nil)
+	var _ UserServiceAPI = (*MockUserService)(nil)
+}
+
+func TestMockUserService_DefaultsToNil(t *testing.T) {
+	mock := &MockUserService{}
+	ctx := context.Background()
+
+	user, err := mock.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if user != nil {
+		t.Fatalf("expected nil result, got: %v", user)
+	}
+}
+
+func TestMockUserService_CallsFunc(t *testing.T) {
+	called := false
+	mock := &MockUserService{
+		GetFunc: func(ctx context.Context, id int64) (*User, error) {
+			called = true
+			return &User{ID: id}, nil
+		},
+	}
+
+	user, err := mock.Get(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected GetFunc to be called")
+	}
+	if user.ID != 42 {
+		t.Fatalf("expected ID 42, got %d", user.ID)
+	}
+}

--- a/user_service_test.go
+++ b/user_service_test.go
@@ -1,0 +1,632 @@
+package truenas
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// --- Conversion tests ---
+
+func TestUserFromResponse(t *testing.T) {
+	email := "jdoe@example.com"
+	sshkey := "ssh-rsa AAAA..."
+	resp := UserResponse{
+		ID:       1,
+		UID:      1000,
+		Username: "jdoe",
+		FullName: "John Doe",
+		Email:    &email,
+		Home:     "/home/jdoe",
+		Shell:    "/usr/bin/bash",
+		HomeMode: "755",
+		Group: UserGroupResponse{
+			ID:        10,
+			GID:       1000,
+			GroupName: "jdoe",
+		},
+		Groups:               []int64{20, 30},
+		SMB:                  true,
+		PasswordDisabled:     false,
+		SSHPasswordEnabled:   true,
+		SSHPubKey:            &sshkey,
+		Locked:               false,
+		SudoCommands:         []string{"ALL"},
+		SudoCommandsNopasswd: []string{"/usr/bin/apt"},
+		Builtin:              false,
+		Local:                true,
+		Immutable:            false,
+	}
+
+	user := userFromResponse(resp)
+
+	if user.ID != 1 {
+		t.Errorf("expected ID 1, got %d", user.ID)
+	}
+	if user.UID != 1000 {
+		t.Errorf("expected UID 1000, got %d", user.UID)
+	}
+	if user.Username != "jdoe" {
+		t.Errorf("expected username jdoe, got %s", user.Username)
+	}
+	if user.FullName != "John Doe" {
+		t.Errorf("expected full name John Doe, got %s", user.FullName)
+	}
+	if user.Email != "jdoe@example.com" {
+		t.Errorf("expected email jdoe@example.com, got %s", user.Email)
+	}
+	if user.Home != "/home/jdoe" {
+		t.Errorf("expected home /home/jdoe, got %s", user.Home)
+	}
+	if user.Shell != "/usr/bin/bash" {
+		t.Errorf("expected shell /usr/bin/bash, got %s", user.Shell)
+	}
+	if user.HomeMode != "755" {
+		t.Errorf("expected home mode 755, got %s", user.HomeMode)
+	}
+	if user.GroupID != 10 {
+		t.Errorf("expected GroupID 10, got %d", user.GroupID)
+	}
+	if len(user.Groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(user.Groups))
+	}
+	if !user.SMB {
+		t.Error("expected SMB=true")
+	}
+	if user.PasswordDisabled {
+		t.Error("expected PasswordDisabled=false")
+	}
+	if !user.SSHPasswordEnabled {
+		t.Error("expected SSHPasswordEnabled=true")
+	}
+	if user.SSHPubKey != "ssh-rsa AAAA..." {
+		t.Errorf("expected SSHPubKey, got %s", user.SSHPubKey)
+	}
+	if user.Locked {
+		t.Error("expected Locked=false")
+	}
+	if len(user.SudoCommands) != 1 || user.SudoCommands[0] != "ALL" {
+		t.Errorf("expected SudoCommands=[ALL], got %v", user.SudoCommands)
+	}
+	if !user.Local {
+		t.Error("expected Local=true")
+	}
+	if user.Immutable {
+		t.Error("expected Immutable=false")
+	}
+}
+
+func TestUserFromResponse_NullableFields(t *testing.T) {
+	resp := UserResponse{
+		ID:       2,
+		UID:      1001,
+		Username: "nomail",
+		FullName: "No Mail",
+		Email:    nil,
+		SSHPubKey: nil,
+		Group:    UserGroupResponse{ID: 10},
+	}
+
+	user := userFromResponse(resp)
+
+	if user.Email != "" {
+		t.Errorf("expected empty email for nil, got %q", user.Email)
+	}
+	if user.SSHPubKey != "" {
+		t.Errorf("expected empty SSHPubKey for nil, got %q", user.SSHPubKey)
+	}
+}
+
+func TestCreateUserParams(t *testing.T) {
+	opts := CreateUserOpts{
+		Username:         "jdoe",
+		FullName:         "John Doe",
+		Email:            "jdoe@example.com",
+		UID:              1000,
+		Password:         "secret",
+		PasswordDisabled: false,
+		Group:            10,
+		GroupCreate:      false,
+		Groups:           []int64{20, 30},
+		Home:             "/home/jdoe",
+		HomeCreate:       true,
+		HomeMode:         "755",
+		Shell:            "/usr/bin/bash",
+		SMB:              true,
+		SSHPasswordEnabled: true,
+		SSHPubKey:        "ssh-rsa AAAA...",
+		Locked:           false,
+		SudoCommands:     []string{"ALL"},
+		SudoCommandsNopasswd: []string{"/usr/bin/apt"},
+	}
+
+	params := createUserParams(opts)
+
+	if params["username"] != "jdoe" {
+		t.Errorf("expected username jdoe, got %v", params["username"])
+	}
+	if params["full_name"] != "John Doe" {
+		t.Errorf("expected full_name John Doe, got %v", params["full_name"])
+	}
+	if params["email"] != "jdoe@example.com" {
+		t.Errorf("expected email, got %v", params["email"])
+	}
+	if params["uid"] != int64(1000) {
+		t.Errorf("expected uid 1000, got %v", params["uid"])
+	}
+	if params["password"] != "secret" {
+		t.Errorf("expected password, got %v", params["password"])
+	}
+	if params["group"] != int64(10) {
+		t.Errorf("expected group 10, got %v", params["group"])
+	}
+	if params["group_create"] != false {
+		t.Errorf("expected group_create false, got %v", params["group_create"])
+	}
+	if groups, ok := params["groups"].([]int64); !ok || len(groups) != 2 {
+		t.Errorf("expected groups [20 30], got %v", params["groups"])
+	}
+	if params["home_create"] != true {
+		t.Errorf("expected home_create true, got %v", params["home_create"])
+	}
+	if params["smb"] != true {
+		t.Errorf("expected smb true, got %v", params["smb"])
+	}
+	if params["sshpubkey"] != "ssh-rsa AAAA..." {
+		t.Errorf("expected sshpubkey, got %v", params["sshpubkey"])
+	}
+}
+
+func TestCreateUserParams_Minimal(t *testing.T) {
+	opts := CreateUserOpts{
+		Username: "minimal",
+		FullName: "Minimal User",
+	}
+
+	params := createUserParams(opts)
+
+	if params["username"] != "minimal" {
+		t.Errorf("expected username minimal, got %v", params["username"])
+	}
+	// UID should be omitted when 0
+	if _, ok := params["uid"]; ok {
+		t.Error("expected no uid when 0")
+	}
+	// Password should be omitted when empty
+	if _, ok := params["password"]; ok {
+		t.Error("expected no password when empty")
+	}
+	// Group should be omitted when 0
+	if _, ok := params["group"]; ok {
+		t.Error("expected no group when 0")
+	}
+	// Groups should be omitted when nil
+	if _, ok := params["groups"]; ok {
+		t.Error("expected no groups when nil")
+	}
+	// SSHPubKey should be omitted when empty
+	if _, ok := params["sshpubkey"]; ok {
+		t.Error("expected no sshpubkey when empty")
+	}
+	// SudoCommands should be omitted when nil
+	if _, ok := params["sudo_commands"]; ok {
+		t.Error("expected no sudo_commands when nil")
+	}
+}
+
+func TestUpdateUserParams(t *testing.T) {
+	opts := UpdateUserOpts{
+		Username: "renamed",
+		FullName: "Renamed User",
+		SMB:      true,
+	}
+
+	params := updateUserParams(opts)
+
+	if params["username"] != "renamed" {
+		t.Errorf("expected username renamed, got %v", params["username"])
+	}
+	if params["full_name"] != "Renamed User" {
+		t.Errorf("expected full_name Renamed User, got %v", params["full_name"])
+	}
+	// uid must never be in update params
+	if _, ok := params["uid"]; ok {
+		t.Error("expected no uid in update params")
+	}
+	// group_create must never be in update params
+	if _, ok := params["group_create"]; ok {
+		t.Error("expected no group_create in update params")
+	}
+	// home_create must never be in update params
+	if _, ok := params["home_create"]; ok {
+		t.Error("expected no home_create in update params")
+	}
+}
+
+// --- CRUD tests ---
+
+func TestUserService_Create(t *testing.T) {
+	mock := &mockCaller{}
+	callCount := 0
+	mock.callFunc = func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+		callCount++
+		switch method {
+		case "user.create":
+			p := params.(map[string]any)
+			if p["username"] != "jdoe" {
+				t.Errorf("expected username jdoe, got %v", p["username"])
+			}
+			return json.RawMessage(`{"id": 42}`), nil
+		case "user.get_instance":
+			return json.RawMessage(`{
+				"id":42,"uid":1000,"username":"jdoe","full_name":"John Doe",
+				"email":"jdoe@example.com","home":"/home/jdoe","shell":"/usr/bin/bash",
+				"home_mode":"755","group":{"id":10,"bsdgrp_gid":1000,"bsdgrp_group":"jdoe"},
+				"groups":[],"smb":true,"password_disabled":false,"ssh_password_enabled":false,
+				"locked":false,"builtin":false,"local":true,"immutable":false
+			}`), nil
+		default:
+			t.Errorf("unexpected method: %s", method)
+			return nil, nil
+		}
+	}
+
+	svc := NewUserService(mock, Version{})
+	user, err := svc.Create(context.Background(), CreateUserOpts{
+		Username: "jdoe",
+		FullName: "John Doe",
+		Email:    "jdoe@example.com",
+		Password: "secret",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected non-nil user")
+	}
+	if user.ID != 42 {
+		t.Errorf("expected ID 42, got %d", user.ID)
+	}
+	if user.Username != "jdoe" {
+		t.Errorf("expected username jdoe, got %s", user.Username)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (create + get_instance), got %d", callCount)
+	}
+}
+
+func TestUserService_Create_Error(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return nil, errors.New("permission denied")
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	user, err := svc.Create(context.Background(), CreateUserOpts{Username: "fail"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if user != nil {
+		t.Error("expected nil user on error")
+	}
+}
+
+func TestUserService_Get(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "user.get_instance" {
+				t.Errorf("expected method user.get_instance, got %s", method)
+			}
+			id, ok := params.(int64)
+			if !ok || id != 42 {
+				t.Errorf("expected id 42, got %v", params)
+			}
+			return json.RawMessage(`{
+				"id":42,"uid":1000,"username":"jdoe","full_name":"John Doe",
+				"email":null,"home":"/home/jdoe","shell":"/usr/bin/bash",
+				"home_mode":"755","group":{"id":10,"bsdgrp_gid":1000,"bsdgrp_group":"jdoe"},
+				"groups":[20],"smb":false,"password_disabled":true,"ssh_password_enabled":false,
+				"sshpubkey":null,"locked":false,"builtin":false,"local":true,"immutable":false
+			}`), nil
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	user, err := svc.Get(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected non-nil user")
+	}
+	if user.Username != "jdoe" {
+		t.Errorf("expected username jdoe, got %s", user.Username)
+	}
+	if user.Email != "" {
+		t.Errorf("expected empty email for null, got %q", user.Email)
+	}
+	if user.GroupID != 10 {
+		t.Errorf("expected GroupID 10, got %d", user.GroupID)
+	}
+	if len(user.Groups) != 1 || user.Groups[0] != 20 {
+		t.Errorf("expected groups [20], got %v", user.Groups)
+	}
+	if !user.PasswordDisabled {
+		t.Error("expected PasswordDisabled=true")
+	}
+}
+
+func TestUserService_Get_NotFound(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return nil, errors.New("user 999 does not exist")
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	user, err := svc.Get(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("expected nil error for not-found, got: %v", err)
+	}
+	if user != nil {
+		t.Error("expected nil user for not-found")
+	}
+}
+
+func TestUserService_GetByUsername(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "user.query" {
+				t.Errorf("expected method user.query, got %s", method)
+			}
+			filter, ok := params.([][]any)
+			if !ok {
+				t.Fatal("expected [][]any params")
+			}
+			if len(filter) != 1 || filter[0][0] != "username" || filter[0][1] != "=" || filter[0][2] != "jdoe" {
+				t.Errorf("unexpected filter: %v", filter)
+			}
+			return json.RawMessage(`[{
+				"id":42,"uid":1000,"username":"jdoe","full_name":"John Doe",
+				"email":null,"home":"/home/jdoe","shell":"/usr/bin/bash",
+				"home_mode":"755","group":{"id":10,"bsdgrp_gid":1000,"bsdgrp_group":"jdoe"},
+				"groups":[],"smb":false,"password_disabled":false,"ssh_password_enabled":false,
+				"locked":false,"builtin":false,"local":true,"immutable":false
+			}]`), nil
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	user, err := svc.GetByUsername(context.Background(), "jdoe")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected non-nil user")
+	}
+	if user.Username != "jdoe" {
+		t.Errorf("expected username jdoe, got %s", user.Username)
+	}
+}
+
+func TestUserService_GetByUsername_NotFound(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return json.RawMessage(`[]`), nil
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	user, err := svc.GetByUsername(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if user != nil {
+		t.Error("expected nil user for not-found")
+	}
+}
+
+func TestUserService_GetByUID(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			filter := params.([][]any)
+			if filter[0][0] != "uid" || filter[0][2] != int64(1000) {
+				t.Errorf("unexpected filter: %v", filter)
+			}
+			return json.RawMessage(`[{
+				"id":42,"uid":1000,"username":"jdoe","full_name":"John Doe",
+				"email":null,"home":"/home/jdoe","shell":"/usr/bin/bash",
+				"home_mode":"755","group":{"id":10,"bsdgrp_gid":1000,"bsdgrp_group":"jdoe"},
+				"groups":[],"smb":false,"password_disabled":false,"ssh_password_enabled":false,
+				"locked":false,"builtin":false,"local":true,"immutable":false
+			}]`), nil
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	user, err := svc.GetByUID(context.Background(), 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected non-nil user")
+	}
+	if user.UID != 1000 {
+		t.Errorf("expected UID 1000, got %d", user.UID)
+	}
+}
+
+func TestUserService_List(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "user.query" {
+				t.Errorf("expected method user.query, got %s", method)
+			}
+			if params != nil {
+				t.Error("expected nil params for List")
+			}
+			return json.RawMessage(`[
+				{"id":1,"uid":0,"username":"root","full_name":"root","home":"/root","shell":"/usr/bin/zsh","home_mode":"755","group":{"id":1,"bsdgrp_gid":0,"bsdgrp_group":"wheel"},"groups":[],"smb":false,"password_disabled":false,"ssh_password_enabled":false,"locked":false,"builtin":true,"local":true,"immutable":true},
+				{"id":42,"uid":1000,"username":"jdoe","full_name":"John Doe","home":"/home/jdoe","shell":"/usr/bin/bash","home_mode":"755","group":{"id":10,"bsdgrp_gid":1000,"bsdgrp_group":"jdoe"},"groups":[],"smb":true,"password_disabled":false,"ssh_password_enabled":false,"locked":false,"builtin":false,"local":true,"immutable":false}
+			]`), nil
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	users, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	if users[0].Username != "root" {
+		t.Errorf("expected first user root, got %s", users[0].Username)
+	}
+	if users[1].Username != "jdoe" {
+		t.Errorf("expected second user jdoe, got %s", users[1].Username)
+	}
+}
+
+func TestUserService_List_Empty(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return json.RawMessage(`[]`), nil
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	users, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(users) != 0 {
+		t.Errorf("expected 0 users, got %d", len(users))
+	}
+}
+
+func TestUserService_Update(t *testing.T) {
+	mock := &mockCaller{}
+	callCount := 0
+	mock.callFunc = func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+		callCount++
+		switch method {
+		case "user.update":
+			slice := params.([]any)
+			if slice[0] != int64(42) {
+				t.Errorf("expected id 42, got %v", slice[0])
+			}
+			p := slice[1].(map[string]any)
+			if p["full_name"] != "Jane Doe" {
+				t.Errorf("expected full_name Jane Doe, got %v", p["full_name"])
+			}
+			// Verify immutable fields are not included
+			if _, ok := p["uid"]; ok {
+				t.Error("uid must not be in update params")
+			}
+			if _, ok := p["group_create"]; ok {
+				t.Error("group_create must not be in update params")
+			}
+			if _, ok := p["home_create"]; ok {
+				t.Error("home_create must not be in update params")
+			}
+			return nil, nil
+		case "user.get_instance":
+			return json.RawMessage(`{
+				"id":42,"uid":1000,"username":"jdoe","full_name":"Jane Doe",
+				"email":null,"home":"/home/jdoe","shell":"/usr/bin/bash",
+				"home_mode":"755","group":{"id":10,"bsdgrp_gid":1000,"bsdgrp_group":"jdoe"},
+				"groups":[],"smb":false,"password_disabled":false,"ssh_password_enabled":false,
+				"locked":false,"builtin":false,"local":true,"immutable":false
+			}`), nil
+		default:
+			t.Errorf("unexpected method: %s", method)
+			return nil, nil
+		}
+	}
+
+	svc := NewUserService(mock, Version{})
+	user, err := svc.Update(context.Background(), 42, UpdateUserOpts{
+		Username: "jdoe",
+		FullName: "Jane Doe",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected non-nil user")
+	}
+	if user.FullName != "Jane Doe" {
+		t.Errorf("expected full_name Jane Doe, got %s", user.FullName)
+	}
+}
+
+func TestUserService_Update_Error(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return nil, errors.New("not found")
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	_, err := svc.Update(context.Background(), 999, UpdateUserOpts{Username: "fail"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUserService_Delete(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "user.delete" {
+				t.Errorf("expected method user.delete, got %s", method)
+			}
+			slice := params.([]any)
+			if slice[0] != int64(42) {
+				t.Errorf("expected id 42, got %v", slice[0])
+			}
+			opts := slice[1].(map[string]any)
+			if opts["delete_group"] != true {
+				t.Errorf("expected delete_group=true, got %v", opts["delete_group"])
+			}
+			return nil, nil
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	err := svc.Delete(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUserService_Delete_Error(t *testing.T) {
+	mock := &mockCaller{
+		callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			return nil, errors.New("permission denied")
+		},
+	}
+
+	svc := NewUserService(mock, Version{})
+	err := svc.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNewUserService(t *testing.T) {
+	mock := &mockCaller{}
+	v := Version{Major: 25, Minor: 4}
+	svc := NewUserService(mock, v)
+	if svc == nil {
+		t.Fatal("expected non-nil service")
+	}
+	if svc.client != mock {
+		t.Error("expected client to be set")
+	}
+	if svc.version != v {
+		t.Error("expected version to be set")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `GroupService` with Create, Get, GetByName, GetByGID, List, Update, Delete
- Adds `UserService` with Create, Get, GetByUsername, GetByUID, List, Update, Delete
- Both use the `Caller` interface (synchronous operations)
- Full test coverage following existing TDD patterns

Migrates API layer from upstream [terraform-provider-truenas#7](https://github.com/deevus/terraform-provider-truenas/pull/7) by @mircea-pavel-anton.

Closes #7

## Test plan

- [x] All conversion tests pass (response → domain, opts → params)
- [x] CRUD tests verify correct API methods and parameter shapes
- [x] Not-found handling returns nil/nil via `isNotFoundError`
- [x] Nullable fields (email, sshpubkey) handled correctly
- [x] Immutable fields (uid, group_create, home_create) excluded from update params
- [x] Interface + mock compile-time checks pass
- [x] `go test ./... -race -v` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)