### PR TITLE
feat: add catalog app support to AppService

### DIFF
--- a/app.go
+++ b/app.go
@@ -20,7 +20,14 @@ type AppResponse struct {
 	HumanVersion     string                     `json:"human_version"`
 	LatestVersion    string                     `json:"latest_version"`
 	UpgradeAvailable bool                       `json:"upgrade_available"`
+	Metadata         AppMetadataResponse        `json:"metadata"`
 	ActiveWorkloads  AppActiveWorkloadsResponse `json:"active_workloads"`
+}
+
+// AppMetadataResponse contains catalog metadata from the API response.
+type AppMetadataResponse struct {
+	Name  string `json:"name"`
+	Train string `json:"train"`
 }
 
 // AppActiveWorkloadsResponse is the wire-format for active workload data.

--- a/app_service.go
+++ b/app_service.go
@@ -44,6 +44,8 @@ type AppContainerDetails struct {
 }
 
 // CreateAppOpts contains options for creating an app.
+// Set CatalogApp for catalog apps or CustomApp with CustomComposeConfig
+// for custom Docker Compose apps. CatalogApp takes precedence if both are set.
 type CreateAppOpts struct {
 	Name                string
 	CustomApp           bool

--- a/app_service.go
+++ b/app_service.go
@@ -11,6 +11,8 @@ type App struct {
 	Name             string
 	State            string
 	CustomApp        bool
+	CatalogApp       string
+	Train            string
 	Config           map[string]any
 	Version          string
 	HumanVersion     string
@@ -46,11 +48,16 @@ type CreateAppOpts struct {
 	Name                string
 	CustomApp           bool
 	CustomComposeConfig string
+	CatalogApp          string
+	Train               string
+	Version             string
+	Values              map[string]any
 }
 
 // UpdateAppOpts contains options for updating an app.
 type UpdateAppOpts struct {
 	CustomComposeConfig string
+	Values              map[string]any
 }
 
 // Registry is the user-facing representation of a TrueNAS app registry.
@@ -530,11 +537,25 @@ func appImageFromResponse(resp AppImageResponse) AppImage {
 // createAppParams converts CreateAppOpts to API parameters.
 func createAppParams(opts CreateAppOpts) map[string]any {
 	params := map[string]any{
-		"app_name":   opts.Name,
-		"custom_app": opts.CustomApp,
+		"app_name": opts.Name,
 	}
-	if opts.CustomComposeConfig != "" {
-		params["custom_compose_config_string"] = opts.CustomComposeConfig
+	if opts.CatalogApp != "" {
+		params["custom_app"] = false
+		params["catalog_app"] = opts.CatalogApp
+		if opts.Train != "" {
+			params["train"] = opts.Train
+		}
+		if opts.Version != "" {
+			params["version"] = opts.Version
+		}
+		if opts.Values != nil {
+			params["values"] = opts.Values
+		}
+	} else {
+		params["custom_app"] = opts.CustomApp
+		if opts.CustomComposeConfig != "" {
+			params["custom_compose_config_string"] = opts.CustomComposeConfig
+		}
 	}
 	return params
 }
@@ -544,6 +565,9 @@ func updateAppParams(opts UpdateAppOpts) map[string]any {
 	params := map[string]any{}
 	if opts.CustomComposeConfig != "" {
 		params["custom_compose_config_string"] = opts.CustomComposeConfig
+	}
+	if opts.Values != nil {
+		params["values"] = opts.Values
 	}
 	return params
 }
@@ -589,6 +613,8 @@ func appFromResponse(resp AppResponse) App {
 		Name:             resp.Name,
 		State:            resp.State,
 		CustomApp:        resp.CustomApp,
+		CatalogApp:       resp.Metadata.Name,
+		Train:            resp.Metadata.Train,
 		Config:           resp.Config,
 		Version:          resp.Version,
 		HumanVersion:     resp.HumanVersion,

--- a/app_service_conversion_test.go
+++ b/app_service_conversion_test.go
@@ -200,6 +200,27 @@ func TestUpdateAppParams_WithValues(t *testing.T) {
 	}
 }
 
+func TestCreateAppParams_CatalogAppOverridesCustomApp(t *testing.T) {
+	opts := CreateAppOpts{
+		Name:       "confused",
+		CustomApp:  true,
+		CatalogApp: "plex",
+		Train:      "stable",
+	}
+
+	params := createAppParams(opts)
+
+	if params["custom_app"] != false {
+		t.Errorf("expected CatalogApp to override custom_app to false, got %v", params["custom_app"])
+	}
+	if params["catalog_app"] != "plex" {
+		t.Errorf("expected catalog_app 'plex', got %v", params["catalog_app"])
+	}
+	if _, ok := params["custom_compose_config_string"]; ok {
+		t.Error("expected no custom_compose_config_string when CatalogApp is set")
+	}
+}
+
 func TestRegistryFromResponse(t *testing.T) {
 	desc := "A registry"
 	resp := AppRegistryResponse{

--- a/app_service_test.go
+++ b/app_service_test.go
@@ -66,7 +66,7 @@ func TestAppService_CreateApp_Error(t *testing.T) {
 	}}
 
 	svc := NewAppService(mock, Version{})
-	app, err := svc.CreateApp(context.Background(), CreateAppOpts{Name: "fail-app"})
+	app, err := svc.CreateApp(context.Background(), CreateAppOpts{Name: "fail-app", CustomApp: true})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -89,7 +89,7 @@ func TestAppService_CreateApp_NotFoundAfterCreate(t *testing.T) {
 	}
 
 	svc := NewAppService(mock, Version{})
-	app, err := svc.CreateApp(context.Background(), CreateAppOpts{Name: "ghost-app"})
+	app, err := svc.CreateApp(context.Background(), CreateAppOpts{Name: "ghost-app", CustomApp: true})
 	if err == nil {
 		t.Fatal("expected error for not found after create")
 	}
@@ -109,7 +109,7 @@ func TestAppService_CreateApp_ParseError(t *testing.T) {
 	}
 
 	svc := NewAppService(mock, Version{})
-	_, err := svc.CreateApp(context.Background(), CreateAppOpts{Name: "parse-fail"})
+	_, err := svc.CreateApp(context.Background(), CreateAppOpts{Name: "parse-fail", CustomApp: true})
 	if err == nil {
 		t.Fatal("expected parse error")
 	}
@@ -589,7 +589,7 @@ func TestAppService_CreateApp_ReReadError(t *testing.T) {
 	}
 
 	svc := NewAppService(mock, Version{})
-	app, err := svc.CreateApp(context.Background(), CreateAppOpts{Name: "fail-reread"})
+	app, err := svc.CreateApp(context.Background(), CreateAppOpts{Name: "fail-reread", CustomApp: true})
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/app_service_test.go
+++ b/app_service_test.go
@@ -617,3 +617,126 @@ func TestAppService_UpdateApp_ReReadError(t *testing.T) {
 		t.Error("expected nil app on re-read error")
 	}
 }
+
+func TestAppService_CreateApp_CatalogApp(t *testing.T) {
+	var capturedMethod string
+	var capturedParams any
+
+	mock := &mockSubscribeCaller{mockAsyncCaller: mockAsyncCaller{
+		callAndWaitFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			capturedMethod = method
+			capturedParams = params
+			return nil, nil
+		},
+	}}
+	mock.callFunc = func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+		return sampleCatalogAppJSON(), nil
+	}
+
+	svc := NewAppService(mock, Version{})
+	app, err := svc.CreateApp(context.Background(), CreateAppOpts{
+		Name:       "tailscale",
+		CatalogApp: "tailscale",
+		Train:      "community",
+		Values:     map[string]any{"tailscale": map[string]any{"auth_key": "tskey-xxx"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if app == nil {
+		t.Fatal("expected non-nil app")
+	}
+
+	// Verify create method
+	if capturedMethod != "app.create" {
+		t.Errorf("expected method app.create, got %s", capturedMethod)
+	}
+
+	// Verify create params include catalog fields
+	p, ok := capturedParams.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any params, got %T", capturedParams)
+	}
+	if p["catalog_app"] != "tailscale" {
+		t.Errorf("expected catalog_app 'tailscale', got %v", p["catalog_app"])
+	}
+	if p["train"] != "community" {
+		t.Errorf("expected train 'community', got %v", p["train"])
+	}
+	if p["custom_app"] != false {
+		t.Errorf("expected custom_app false, got %v", p["custom_app"])
+	}
+	values, ok := p["values"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected values map, got %T", p["values"])
+	}
+	ts, ok := values["tailscale"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tailscale values map, got %T", values["tailscale"])
+	}
+	if ts["auth_key"] != "tskey-xxx" {
+		t.Errorf("expected auth_key 'tskey-xxx', got %v", ts["auth_key"])
+	}
+
+	// Verify re-read populated catalog metadata
+	if app.CatalogApp != "tailscale" {
+		t.Errorf("expected CatalogApp 'tailscale', got %q", app.CatalogApp)
+	}
+	if app.Train != "community" {
+		t.Errorf("expected Train 'community', got %q", app.Train)
+	}
+	if app.CustomApp {
+		t.Error("expected CustomApp false")
+	}
+	if app.Version != "1.3.32" {
+		t.Errorf("expected Version '1.3.32', got %q", app.Version)
+	}
+}
+
+func TestAppService_UpdateApp_CatalogAppValues(t *testing.T) {
+	var capturedParams any
+
+	mock := &mockSubscribeCaller{mockAsyncCaller: mockAsyncCaller{
+		callAndWaitFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+			if method != "app.update" {
+				t.Errorf("expected method app.update, got %s", method)
+			}
+			capturedParams = params
+			return nil, nil
+		},
+	}}
+	mock.callFunc = func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+		return sampleCatalogAppJSON(), nil
+	}
+
+	svc := NewAppService(mock, Version{})
+	app, err := svc.UpdateApp(context.Background(), "tailscale", UpdateAppOpts{
+		Values: map[string]any{"TZ": "America/New_York"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if app == nil {
+		t.Fatal("expected non-nil app")
+	}
+
+	// Verify update params contain values
+	slice, ok := capturedParams.([]any)
+	if !ok || len(slice) != 2 {
+		t.Fatalf("expected [name, params] slice, got %T", capturedParams)
+	}
+	if slice[0] != "tailscale" {
+		t.Errorf("expected name 'tailscale', got %v", slice[0])
+	}
+	updateMap, ok := slice[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any update params, got %T", slice[1])
+	}
+	values, ok := updateMap["values"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected values map in update params, got %v", updateMap)
+	}
+	if values["TZ"] != "America/New_York" {
+		t.Errorf("expected TZ 'America/New_York', got %v", values["TZ"])
+	}
+}

--- a/app_service_testdata_test.go
+++ b/app_service_testdata_test.go
@@ -21,6 +21,18 @@ func sampleAppWithConfigJSON() json.RawMessage {
 	}]`)
 }
 
+// sampleCatalogAppJSON returns a JSON response for a catalog app with metadata.
+func sampleCatalogAppJSON() json.RawMessage {
+	return json.RawMessage(`[{
+		"name": "tailscale",
+		"state": "RUNNING",
+		"custom_app": false,
+		"version": "1.3.32",
+		"human_version": "Tailscale 1.3.32",
+		"metadata": {"name": "tailscale", "train": "community"}
+	}]`)
+}
+
 // sampleRegistryJSON returns a JSON response for a single registry.
 func sampleRegistryJSON() json.RawMessage {
 	return json.RawMessage(`[{

--- a/client/midclt.go
+++ b/client/midclt.go
@@ -48,11 +48,14 @@ func BuildCommand(method string, params any) string {
 }
 
 // AppCreateParams represents parameters for app.create.
-// Simplified for custom Docker Compose apps only.
 type AppCreateParams struct {
-	AppName                   string `json:"app_name"`
-	CustomApp                 bool   `json:"custom_app"`
-	CustomComposeConfigString string `json:"custom_compose_config_string,omitempty"`
+	AppName                   string         `json:"app_name"`
+	CustomApp                 bool           `json:"custom_app"`
+	CustomComposeConfigString string         `json:"custom_compose_config_string,omitempty"`
+	CatalogApp                string         `json:"catalog_app,omitempty"`
+	Train                     string         `json:"train,omitempty"`
+	Version                   string         `json:"version,omitempty"`
+	Values                    map[string]any `json:"values,omitempty"`
 }
 
 // DatasetCreateParams represents parameters for pool.dataset.create.

--- a/client/midclt_test.go
+++ b/client/midclt_test.go
@@ -130,6 +130,40 @@ func TestBuildCommand_AppCreateParamsWithCompose(t *testing.T) {
 	}
 }
 
+func TestBuildCommand_AppCreateParamsCatalogApp(t *testing.T) {
+	params := AppCreateParams{
+		AppName:    "tailscale",
+		CatalogApp: "tailscale",
+		Train:      "community",
+		Values:     map[string]any{"tailscale": map[string]any{"auth_key": "tskey-xxx"}},
+	}
+
+	got := BuildCommand("app.create", params)
+
+	if got == "" {
+		t.Error("BuildCommand() returned empty string")
+	}
+
+	// Should contain catalog fields
+	if !strings.Contains(got, "catalog_app") {
+		t.Errorf("expected 'catalog_app' in output, got %q", got)
+	}
+	if !strings.Contains(got, "tailscale") {
+		t.Errorf("expected 'tailscale' in output, got %q", got)
+	}
+	if !strings.Contains(got, "community") {
+		t.Errorf("expected 'community' in output, got %q", got)
+	}
+	// custom_app should be false, so it should appear as false
+	if !strings.Contains(got, `"custom_app":false`) {
+		t.Errorf("expected 'custom_app:false' in output, got %q", got)
+	}
+	// Should NOT contain compose config
+	if strings.Contains(got, "custom_compose_config_string") {
+		t.Errorf("expected no 'custom_compose_config_string' for catalog app, got %q", got)
+	}
+}
+
 func TestBuildCommand_MarshalError(t *testing.T) {
 	// Create an unmarshallable type (channel) to trigger json.Marshal error
 	params := make(chan int)


### PR DESCRIPTION
## Summary

- Extend `AppService` to support TrueNAS catalog apps (plex, tailscale, jellyfin) alongside existing custom Docker Compose apps
- Add `CatalogApp`, `Train`, `Version`, `Values` fields to `CreateAppOpts`
- Add `Values` field to `UpdateAppOpts`
- Add `AppMetadataResponse` wire type and populate `App.CatalogApp`/`App.Train` from API metadata
- `createAppParams()` sets `custom_app: false` and includes catalog fields when `CatalogApp` is set

Closes #6

Migrated from [terraform-provider-truenas#6](https://github.com/deevus/terraform-provider-truenas/pull/6) by @f33rx — implementation commit attributed to the original author.

## Test plan

- [x] `TestAppFromResponse_CatalogApp` — metadata populates CatalogApp/Train
- [x] `TestCreateAppParams_CatalogApp` — catalog fields in params, custom_app=false
- [x] `TestCreateAppParams_CatalogAppWithValues` — includes parsed values
- [x] `TestUpdateAppParams_WithValues` — values in update params
- [x] `TestAppService_CreateApp_CatalogApp` — end-to-end create with catalog params
- [x] `TestAppService_UpdateApp_CatalogAppValues` — end-to-end update with values
- [x] Full suite passes with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)