### PR TITLE
fix: make io_type optional when creating/updating disk device

### DIFF
--- a/vm_service.go
+++ b/vm_service.go
@@ -73,7 +73,7 @@ type StopVMOpts struct {
 type DiskDevice struct {
 	Path                string
 	Type                string
-	IOType              string
+	IOType              *string
 	Serial              string
 	PhysicalSectorSize  *int64
 	Logical_Sector_Size *int64
@@ -84,7 +84,7 @@ type RawDevice struct {
 	Path                string
 	Type                string
 	Boot                bool
-	IOType              string
+	IOType              *string
 	Serial              string
 	Exists              bool
 	Size                *int64
@@ -359,7 +359,7 @@ func deviceOptsToParams(opts CreateVMDeviceOpts) map[string]any {
 		if opts.Disk != nil {
 			setNonEmpty(attrs, "path", opts.Disk.Path)
 			setNonEmpty(attrs, "type", opts.Disk.Type)
-			setNonEmpty(attrs, "io_type", opts.Disk.IOType)
+			setNonNilString(attrs, "io_type", opts.Disk.IOType)
 			setNonEmpty(attrs, "serial", opts.Disk.Serial)
 			setNonNilInt(attrs, "physical_sectorsize", opts.Disk.PhysicalSectorSize)
 			setNonNilInt(attrs, "logical_sectorsize", opts.Disk.Logical_Sector_Size)
@@ -369,7 +369,7 @@ func deviceOptsToParams(opts CreateVMDeviceOpts) map[string]any {
 			setNonEmpty(attrs, "path", opts.Raw.Path)
 			setNonEmpty(attrs, "type", opts.Raw.Type)
 			attrs["boot"] = opts.Raw.Boot
-			setNonEmpty(attrs, "io_type", opts.Raw.IOType)
+			setNonNilString(attrs, "io_type", opts.Raw.IOType)
 			setNonEmpty(attrs, "serial", opts.Raw.Serial)
 			attrs["exists"] = opts.Raw.Exists
 			setNonNilInt(attrs, "size", opts.Raw.Size)
@@ -436,6 +436,13 @@ func setNonNilInt(m map[string]any, key string, value *int64) {
 	}
 }
 
+// setNonNilString sets a map key only if the value is non-nil.
+func setNonNilString(m map[string]any, key string, value *string) {
+	if value != nil {
+		m[key] = *value
+	}
+}
+
 // vmFromResponse converts a VMResponse to a user-facing VM.
 func vmFromResponse(resp VMResponse) VM {
 	cpuModel := ""
@@ -480,7 +487,7 @@ func vmDeviceFromResponse(resp VMDeviceResponse) VMDevice {
 		device.Disk = &DiskDevice{
 			Path:                stringFromMap(resp.Attributes, "path"),
 			Type:                stringFromMap(resp.Attributes, "type"),
-			IOType:              stringFromMap(resp.Attributes, "io_type"),
+			IOType:              strPtrFromMap(resp.Attributes, "io_type"),
 			Serial:              stringFromMap(resp.Attributes, "serial"),
 			PhysicalSectorSize:  intPtrFromMap(resp.Attributes, "physical_sectorsize"),
 			Logical_Sector_Size: intPtrFromMap(resp.Attributes, "logical_sectorsize"),
@@ -490,7 +497,7 @@ func vmDeviceFromResponse(resp VMDeviceResponse) VMDevice {
 			Path:                stringFromMap(resp.Attributes, "path"),
 			Type:                stringFromMap(resp.Attributes, "type"),
 			Boot:                boolFromMap(resp.Attributes, "boot"),
-			IOType:              stringFromMap(resp.Attributes, "io_type"),
+			IOType:              strPtrFromMap(resp.Attributes, "io_type"),
 			Serial:              stringFromMap(resp.Attributes, "serial"),
 			Exists:              boolFromMap(resp.Attributes, "exists"),
 			Size:                intPtrFromMap(resp.Attributes, "size"),
@@ -545,6 +552,19 @@ func stringFromMap(m map[string]any, key string) string {
 		return ""
 	}
 	return s
+}
+
+// strPtrFromMap extracts a *string value from a map. Returns nil if the key is absent or null.
+func strPtrFromMap(m map[string]any, key string) *string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	return &s
 }
 
 // boolFromMap extracts a bool value from a map.

--- a/vm_service_conversion_test.go
+++ b/vm_service_conversion_test.go
@@ -97,6 +97,37 @@ func TestVMDeviceFromResponse_Disk(t *testing.T) {
 	if device.Disk.PhysicalSectorSize != nil {
 		t.Errorf("expected nil PhysicalSectorSize, got %v", device.Disk.PhysicalSectorSize)
 	}
+	if device.Disk.IOType != nil {
+		t.Errorf("expected nil IOType when absent, got %v", device.Disk.IOType)
+	}
+}
+
+func TestVMDeviceFromResponse_Disk_WithIOType(t *testing.T) {
+	resp := VMDeviceResponse{
+		ID:    10,
+		VM:    1,
+		Order: 1001,
+		Attributes: map[string]any{
+			"dtype":   "DISK",
+			"path":    "/dev/zvol/tank/vm-disk",
+			"type":    "VIRTIO",
+			"io_type": "NATIVE",
+		},
+	}
+
+	device := vmDeviceFromResponse(resp)
+	if device.DeviceType != DeviceTypeDisk {
+		t.Errorf("expected DISK, got %s", device.DeviceType)
+	}
+	if device.Disk == nil {
+		t.Fatal("expected non-nil Disk")
+	}
+	if device.Disk.IOType == nil {
+		t.Fatal("expected non-nil IOType")
+	}
+	if *device.Disk.IOType != "NATIVE" {
+		t.Errorf("expected IOType NATIVE, got %s", *device.Disk.IOType)
+	}
 }
 
 func TestVMDeviceFromResponse_Raw(t *testing.T) {
@@ -125,6 +156,36 @@ func TestVMDeviceFromResponse_Raw(t *testing.T) {
 	}
 	if device.Raw.Size == nil || *device.Raw.Size != 10737418240 {
 		t.Errorf("expected size 10737418240, got %v", device.Raw.Size)
+	}
+}
+
+func TestVMDeviceFromResponse_RAW_WithIOType(t *testing.T) {
+	resp := VMDeviceResponse{
+		ID:    10,
+		VM:    1,
+		Order: 1001,
+		Attributes: map[string]any{
+			"dtype":   "RAW",
+			"path":    "/mnt/tank/vm/raw.img",
+			"type":    "VIRTIO",
+			"boot":    true,
+			"size":    float64(10737418240),
+			"io_type": "NATIVE",
+		},
+	}
+
+	device := vmDeviceFromResponse(resp)
+	if device.DeviceType != DeviceTypeRaw {
+		t.Errorf("expected RAW, got %s", device.DeviceType)
+	}
+	if device.Raw == nil {
+		t.Fatal("expected non-nil Raw")
+	}
+	if device.Raw.IOType == nil {
+		t.Fatal("expected non-nil IOType")
+	}
+	if *device.Raw.IOType != "NATIVE" {
+		t.Errorf("expected IOType NATIVE, got %s", *device.Raw.IOType)
 	}
 }
 

--- a/vm_service_params_test.go
+++ b/vm_service_params_test.go
@@ -236,3 +236,128 @@ func TestSetNonNilInt(t *testing.T) {
 		t.Error("expected key2 to be absent for nil")
 	}
 }
+
+func TestSetNonNilString(t *testing.T) {
+	m := map[string]any{}
+	val := "test-value"
+	setNonNilString(m, "key1", &val)
+	setNonNilString(m, "key2", nil)
+
+	if m["key1"] != "test-value" {
+		t.Errorf("expected key1=test-value, got %v", m["key1"])
+	}
+	if _, ok := m["key2"]; ok {
+		t.Error("expected key2 to be absent for nil")
+	}
+}
+
+func TestStrPtrFromMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		m       map[string]any
+		key     string
+		wantNil bool
+		want    string
+	}{
+		{"existing string", map[string]any{"key": "value"}, "key", false, "value"},
+		{"missing key", map[string]any{}, "key", true, ""},
+		{"nil value", map[string]any{"key": nil}, "key", true, ""},
+		{"non-string value", map[string]any{"key": 123}, "key", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strPtrFromMap(tt.m, tt.key)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("strPtrFromMap() = %v, want nil", *got)
+				}
+			} else {
+				if got == nil {
+					t.Fatal("strPtrFromMap() = nil, want non-nil")
+				}
+				if *got != tt.want {
+					t.Errorf("strPtrFromMap() = %q, want %q", *got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestDeviceOptsToParams_Disk_IOType(t *testing.T) {
+	t.Run("IOType set", func(t *testing.T) {
+		ioType := "NATIVE"
+		opts := CreateVMDeviceOpts{
+			VM:         1,
+			DeviceType: DeviceTypeDisk,
+			Disk: &DiskDevice{
+				Path:   "/dev/zvol/tank/vm-disk",
+				IOType: &ioType,
+			},
+		}
+
+		params := deviceOptsToParams(opts)
+		attrs := params["attributes"].(map[string]any)
+
+		if attrs["io_type"] != "NATIVE" {
+			t.Errorf("expected io_type=NATIVE, got %v", attrs["io_type"])
+		}
+	})
+
+	t.Run("IOType nil", func(t *testing.T) {
+		opts := CreateVMDeviceOpts{
+			VM:         1,
+			DeviceType: DeviceTypeDisk,
+			Disk: &DiskDevice{
+				Path:   "/dev/zvol/tank/vm-disk",
+				IOType: nil,
+			},
+		}
+
+		params := deviceOptsToParams(opts)
+		attrs := params["attributes"].(map[string]any)
+
+		if _, ok := attrs["io_type"]; ok {
+			t.Error("expected io_type to be absent when nil")
+		}
+	})
+}
+
+func TestDeviceOptsToParams_RAW_IOType(t *testing.T) {
+	t.Run("IOType set", func(t *testing.T) {
+		ioType := "NATIVE"
+		opts := CreateVMDeviceOpts{
+			VM:         1,
+			DeviceType: DeviceTypeRaw,
+			Raw: &RawDevice{
+				Path:   "/dev/zvol/tank/vm-disk",
+				IOType: &ioType,
+			},
+		}
+
+		params := deviceOptsToParams(opts)
+		attrs := params["attributes"].(map[string]any)
+
+		if attrs["io_type"] != "NATIVE" {
+			t.Errorf("expected io_type=NATIVE, got %v", attrs["io_type"])
+		}
+	})
+
+	t.Run("IOType nil", func(t *testing.T) {
+		opts := CreateVMDeviceOpts{
+			VM:         1,
+			DeviceType: DeviceTypeRaw,
+			Raw: &RawDevice{
+				Path:   "/dev/zvol/tank/vm-disk",
+				IOType: nil,
+			},
+		}
+
+		params := deviceOptsToParams(opts)
+		attrs := params["attributes"].(map[string]any)
+
+		if _, ok := attrs["io_type"]; ok {
+			t.Error("expected io_type to be absent when nil")
+		}
+	})
+}


### PR DESCRIPTION
Makes `io_type` attribute for disk and raw device optional to resolve the following error:

```
truenas_vm.home_assistant_vm: Modifying... [id=1]
╷
│ Error: Unable to Update VM Devices
│
│   with truenas_vm.home_assistant_vm,
│   on home_assistant_vm.tf line 9, in resource "truenas_vm" "home_assistant_vm":
│    9: resource "truenas_vm" "home_assistant_vm" {
│
│ failed to update disk device 1: Process exited with status 1: [EINVAL] vm_device_update.attributes.DISK.io_type: Extra inputs are not permitted
```

Not sure this is the best solution or if you would rather implement a separate create/update logic to better handle attributes not permitted when updating a disk device? Would appreciate some feedback. 

Fixes https://github.com/deevus/terraform-provider-truenas/issues/11