### PR TITLE
feat: add webdav support for cloudsync tasks/credentials

### DIFF
--- a/cloudsync.go
+++ b/cloudsync.go
@@ -26,7 +26,7 @@ type CloudSyncCredentialProvider struct {
 	// GCS attributes
 	ServiceAccountCredentials string `json:"service_account_credentials,omitempty"`
 	// WebDAV attributes
-	Url    string `json:"url,omitempty"`
+	URL    string `json:"url,omitempty"`
 	Vendor string `json:"vendor,omitempty"`
 	User   string `json:"user,omitempty"`
 	Pass   string `json:"pass,omitempty"`

--- a/cloudsync.go
+++ b/cloudsync.go
@@ -25,6 +25,11 @@ type CloudSyncCredentialProvider struct {
 	Key     string `json:"key,omitempty"`
 	// GCS attributes
 	ServiceAccountCredentials string `json:"service_account_credentials,omitempty"`
+	// WebDAV attributes
+	Url    string `json:"url,omitempty"`
+	Vendor string `json:"vendor,omitempty"`
+	User   string `json:"user,omitempty"`
+	Pass   string `json:"pass,omitempty"`
 }
 
 // CloudSyncTaskCredentialRef is a minimal struct for embedded credential references in tasks.

--- a/cloudsync_service.go
+++ b/cloudsync_service.go
@@ -257,7 +257,7 @@ func credentialFromResponse(resp CloudSyncCredentialResponse) CloudSyncCredentia
 	addIfNonEmpty(attrs, "account", resp.Provider.Account)
 	addIfNonEmpty(attrs, "key", resp.Provider.Key)
 	addIfNonEmpty(attrs, "service_account_credentials", resp.Provider.ServiceAccountCredentials)
-	addIfNonEmpty(attrs, "url", resp.Provider.Url)
+	addIfNonEmpty(attrs, "url", resp.Provider.URL)
 	addIfNonEmpty(attrs, "vendor", resp.Provider.Vendor)
 	addIfNonEmpty(attrs, "user", resp.Provider.User)
 	addIfNonEmpty(attrs, "pass", resp.Provider.Pass)

--- a/cloudsync_service.go
+++ b/cloudsync_service.go
@@ -257,6 +257,10 @@ func credentialFromResponse(resp CloudSyncCredentialResponse) CloudSyncCredentia
 	addIfNonEmpty(attrs, "account", resp.Provider.Account)
 	addIfNonEmpty(attrs, "key", resp.Provider.Key)
 	addIfNonEmpty(attrs, "service_account_credentials", resp.Provider.ServiceAccountCredentials)
+	addIfNonEmpty(attrs, "url", resp.Provider.Url)
+	addIfNonEmpty(attrs, "vendor", resp.Provider.Vendor)
+	addIfNonEmpty(attrs, "user", resp.Provider.User)
+	addIfNonEmpty(attrs, "pass", resp.Provider.Pass)
 	return CloudSyncCredential{
 		ID:           resp.ID,
 		Name:         resp.Name,

--- a/cloudsync_service_conversion_test.go
+++ b/cloudsync_service_conversion_test.go
@@ -89,6 +89,40 @@ func TestCredentialFromResponse_GCS(t *testing.T) {
 	}
 }
 
+func TestCredentialFromResponse_WebDAV(t *testing.T) {
+	resp := CloudSyncCredentialResponse{
+		ID:   1,
+		Name: "WebDAV Cred",
+		Provider: CloudSyncCredentialProvider{
+			Type:   "WEBDAV",
+			Url:    "https://webdav.example.com",
+			Vendor: "example",
+			User:   "someuser",
+			Pass:   "somepass",
+		},
+	}
+
+	cred := credentialFromResponse(resp)
+	if cred.ID != 1 {
+		t.Errorf("expected ID 1, got %d", cred.ID)
+	}
+	if cred.ProviderType != "WEBDAV" {
+		t.Errorf("expected provider type WEBDAV, got %s", cred.ProviderType)
+	}
+	if cred.Attributes["url"] != "https://webdav.example.com" {
+		t.Errorf("expected url https://webdav.example.com, got %s", cred.Attributes["access_key_id"])
+	}
+	if cred.Attributes["vendor"] != "example" {
+		t.Errorf("expected vendor example, got %s", cred.Attributes["secret_access_key"])
+	}
+	if cred.Attributes["user"] != "someuser" {
+		t.Errorf("expected user someuser, got %s", cred.Attributes["endpoint"])
+	}
+	if cred.Attributes["pass"] != "somepass" {
+		t.Errorf("expected pass somepass, got %s", cred.Attributes["region"])
+	}
+}
+
 func TestCredentialFromResponse_EmptyProvider(t *testing.T) {
 	resp := CloudSyncCredentialResponse{
 		ID:   4,

--- a/cloudsync_service_conversion_test.go
+++ b/cloudsync_service_conversion_test.go
@@ -95,7 +95,7 @@ func TestCredentialFromResponse_WebDAV(t *testing.T) {
 		Name: "WebDAV Cred",
 		Provider: CloudSyncCredentialProvider{
 			Type:   "WEBDAV",
-			Url:    "https://webdav.example.com",
+			URL:    "https://webdav.example.com",
 			Vendor: "example",
 			User:   "someuser",
 			Pass:   "somepass",
@@ -110,16 +110,16 @@ func TestCredentialFromResponse_WebDAV(t *testing.T) {
 		t.Errorf("expected provider type WEBDAV, got %s", cred.ProviderType)
 	}
 	if cred.Attributes["url"] != "https://webdav.example.com" {
-		t.Errorf("expected url https://webdav.example.com, got %s", cred.Attributes["access_key_id"])
+		t.Errorf("expected url https://webdav.example.com, got %s", cred.Attributes["url"])
 	}
 	if cred.Attributes["vendor"] != "example" {
-		t.Errorf("expected vendor example, got %s", cred.Attributes["secret_access_key"])
+		t.Errorf("expected vendor example, got %s", cred.Attributes["vendor"])
 	}
 	if cred.Attributes["user"] != "someuser" {
-		t.Errorf("expected user someuser, got %s", cred.Attributes["endpoint"])
+		t.Errorf("expected user someuser, got %s", cred.Attributes["user"])
 	}
 	if cred.Attributes["pass"] != "somepass" {
-		t.Errorf("expected pass somepass, got %s", cred.Attributes["region"])
+		t.Errorf("expected pass somepass, got %s", cred.Attributes["pass"])
 	}
 }
 


### PR DESCRIPTION
Adds support for the WebDAV provider in Cloud Credentials.

I've also got a local commit ready for a PR on the terraform-provider-truenas repo that depends on the changes in this PR. I don't know what the process is for this kind of change, so just let me know when I can create a PR in the other repo.