### PR TITLE
feat: add pre/post-script options to cloudsync task

### DIFF
--- a/cloudsync.go
+++ b/cloudsync.go
@@ -63,6 +63,8 @@ type CloudSyncTaskResponse struct {
 	CreateEmptySrcDirs bool                       `json:"create_empty_src_dirs"`
 	Enabled            bool                       `json:"enabled"`
 	Job                *JobStatus                 `json:"job,omitempty"`
+	PreScript          string                     `json:"pre_script"`
+	PostScript         string                     `json:"post_script"`
 }
 
 // BwLimit represents a bandwidth limit entry.

--- a/cloudsync_service.go
+++ b/cloudsync_service.go
@@ -46,6 +46,8 @@ type CloudSyncTask struct {
 	Attributes         map[string]any
 	Exclude            []string
 	Include            []string
+	PreScript          string
+	PostScript         string
 }
 
 // CreateCloudSyncTaskOpts contains options for creating a cloud sync task.
@@ -69,6 +71,8 @@ type CreateCloudSyncTaskOpts struct {
 	Attributes         map[string]any
 	Exclude            []string
 	Include            []string
+	PreScript          string
+	PostScript         string
 }
 
 // UpdateCloudSyncTaskOpts contains options for updating a cloud sync task.
@@ -335,6 +339,14 @@ func taskOptsToParams(opts CreateCloudSyncTaskOpts) map[string]any {
 		params["include"] = opts.Include
 	}
 
+	if len(opts.PreScript) > 0 {
+		params["pre_script"] = opts.PreScript
+	}
+
+	if len(opts.PostScript) > 0 {
+		params["post_script"] = opts.PostScript
+	}
+
 	return params
 }
 
@@ -363,8 +375,10 @@ func taskFromResponse(resp CloudSyncTaskResponse) CloudSyncTask {
 			Month:  resp.Schedule.Month,
 			Dow:    resp.Schedule.Dow,
 		},
-		Exclude: resp.Exclude,
-		Include: resp.Include,
+		Exclude:    resp.Exclude,
+		Include:    resp.Include,
+		PreScript:  resp.PreScript,
+		PostScript: resp.PostScript,
 	}
 
 	// Handle attributes - can be false in API response, so ignore unmarshal errors

--- a/cloudsync_service.go
+++ b/cloudsync_service.go
@@ -339,13 +339,8 @@ func taskOptsToParams(opts CreateCloudSyncTaskOpts) map[string]any {
 		params["include"] = opts.Include
 	}
 
-	if len(opts.PreScript) > 0 {
-		params["pre_script"] = opts.PreScript
-	}
-
-	if len(opts.PostScript) > 0 {
-		params["post_script"] = opts.PostScript
-	}
+	params["pre_script"] = opts.PreScript
+	params["post_script"] = opts.PostScript
 
 	return params
 }

--- a/cloudsync_service_conversion_test.go
+++ b/cloudsync_service_conversion_test.go
@@ -186,6 +186,8 @@ func TestTaskOptsToParams(t *testing.T) {
 		Attributes: map[string]any{"bucket": "my-bucket"},
 		Exclude:    []string{"*.tmp"},
 		Include:    []string{"*.dat"},
+		PreScript:  "pre-script test",
+		PostScript: "post-script test",
 	}
 
 	params := taskOptsToParams(opts)
@@ -228,6 +230,12 @@ func TestTaskOptsToParams(t *testing.T) {
 	}
 	if _, ok := params["attributes"]; !ok {
 		t.Error("expected attributes in params")
+	}
+	if _, ok := params["pre_script"]; !ok {
+		t.Error("expected pre_script in params")
+	}
+	if _, ok := params["post_script"]; !ok {
+		t.Error("expected post_script in params")
 	}
 }
 

--- a/cloudsync_service_task_test.go
+++ b/cloudsync_service_task_test.go
@@ -47,6 +47,14 @@ func TestCloudSyncService_CreateTask(t *testing.T) {
 					if _, ok := p["exclude"]; !ok {
 						t.Error("expected exclude in params")
 					}
+					// Verify pre_script present
+					if _, ok := p["pre_script"]; !ok {
+						t.Error("expected pre_script in params")
+					}
+					// Verify post_script present
+					if _, ok := p["post_script"]; !ok {
+						t.Error("expected post_script in params")
+					}
 					return json.RawMessage(`{"id": 1}`), nil
 				}
 				return sampleTaskJSON(), nil
@@ -77,6 +85,8 @@ func TestCloudSyncService_CreateTask(t *testing.T) {
 		},
 		Attributes: map[string]any{"bucket": "my-bucket", "folder": "/backups"},
 		Exclude:    []string{"*.tmp"},
+		PreScript:  "pre_script test",
+		PostScript: "post_script test",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -116,6 +126,12 @@ func TestCloudSyncService_CreateTask(t *testing.T) {
 	}
 	if !task.CreateEmptySrcDirs {
 		t.Error("expected create_empty_src_dirs=true")
+	}
+	if task.PreScript != "pre_script test" {
+		t.Errorf("expected pre_script 'pre_script test', got %s", task.PreScript)
+	}
+	if task.PostScript != "post_script test" {
+		t.Errorf("expected post_script 'post_script test', got %s", task.PostScript)
 	}
 }
 
@@ -320,7 +336,8 @@ func TestCloudSyncService_ListTasks(t *testing.T) {
 						"direction": "PUSH", "transfer_mode": "SYNC",
 						"encryption": false, "snapshot": false, "transfers": 4,
 						"bwlimit": [], "exclude": [], "include": [],
-						"follow_symlinks": false, "create_empty_src_dirs": false, "enabled": true
+						"follow_symlinks": false, "create_empty_src_dirs": false, "enabled": true,
+						"pre_script": "pre_script test", "post_script": "post_script test"
 					},
 					{
 						"id": 2, "description": "Task 2", "path": "/mnt/b",
@@ -330,7 +347,8 @@ func TestCloudSyncService_ListTasks(t *testing.T) {
 						"direction": "PULL", "transfer_mode": "COPY",
 						"encryption": false, "snapshot": false, "transfers": 2,
 						"bwlimit": [], "exclude": [], "include": [],
-						"follow_symlinks": false, "create_empty_src_dirs": false, "enabled": false
+						"follow_symlinks": false, "create_empty_src_dirs": false, "enabled": false,
+						"pre_script": "", "post_script": ""
 					}
 				]`), nil
 			},

--- a/cloudsync_service_testdata_test.go
+++ b/cloudsync_service_testdata_test.go
@@ -53,7 +53,9 @@ func sampleTaskJSON() json.RawMessage {
 		"include": [],
 		"follow_symlinks": false,
 		"create_empty_src_dirs": true,
-		"enabled": true
+		"enabled": true,
+		"pre_script": "pre_script test",
+		"post_script": "post_script test"
 	}]`)
 }
 
@@ -78,6 +80,8 @@ func sampleTaskFalseAttrsJSON() json.RawMessage {
 		"include": ["*.dat"],
 		"follow_symlinks": true,
 		"create_empty_src_dirs": false,
-		"enabled": false
+		"enabled": false,
+		"pre_script": "",
+		"post_script": ""
 	}]`)
 }


### PR DESCRIPTION
This PR adds fields to cloudsync tasks for pre-script & post-script options. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud sync tasks now support optional pre-script and post-script fields.
  * These scripts can be provided when creating/updating tasks and are included in task details and task list results.

* **Tests**
  * Added/updated coverage to verify scripts are sent in task requests, parsed from API responses, and handled correctly for tasks with empty (unset) scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->