### PR TITLE
feat: add api's for ssh keypairs and connections

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2,7 +2,7 @@
 
 TrueNAS version: 25.04
 
-Total API methods: 771 | Implemented: 74 (9.6%) | Tested: 74 (100.0% of implemented)
+Total API methods: 771 | Implemented: 78 (10.1%) | Tested: 78 (100.0% of implemented)
 
 ## Covered Namespaces
 
@@ -15,6 +15,7 @@ Total API methods: 771 | Implemented: 74 (9.6%) | Tested: 74 (100.0% of implemen
 | DockerService | docker | 8 | 2 (25%) | 2 (100%) |
 | FilesystemService | filesystem | 13 | 2 (15%) | 2 (100%) |
 | InterfaceService | interface | 23 | 1 (4%) | 1 (100%) |
+| SSHService | keychaincredential | 10 | 4 (40%) | 4 (100%) |
 | NetworkService | network.general | 1 | 1 (100%) | 1 (100%) |
 | ReportingService | reporting | 8 | 2 (25%) | 2 (100%) |
 | SnapshotService | zfs.snapshot | 9 | 7 (78%) | 7 (100%) |
@@ -235,6 +236,21 @@ Total API methods: 771 | Implemented: 74 (9.6%) | Tested: 74 (100.0% of implemen
 | interface.websocket_local_ip |  |  |  |  |
 | interface.xmit_hash_policy_choices |  |  |  |  |
 
+### SSHService — `keychaincredential` (10 methods)
+
+| API Method | Implemented | Go Method | Tested | Tests |
+|------------|:-----------:|-----------|:------:|------:|
+| keychaincredential.create | ✓ | CreateSSHKeyPair, CreateSSHConnection | ✓ | 6 |
+| keychaincredential.delete | ✓ | DeleteSSHKeyPair, DeleteSSHConnection | ✓ | 4 |
+| keychaincredential.generate_ssh_key_pair |  |  |  |  |
+| keychaincredential.get_instance |  |  |  |  |
+| keychaincredential.query | ✓ | GetSSHKeyPair, ListSSHKeyPairs, GetSSHConnection, ListSSHConnections | ✓ | 16 |
+| keychaincredential.remote_ssh_host_key_scan |  |  |  |  |
+| keychaincredential.remote_ssh_semiautomatic_setup |  |  |  |  |
+| keychaincredential.setup_ssh_connection |  |  |  |  |
+| keychaincredential.update | ✓ | UpdateSSHKeyPair, UpdateSSHConnection | ✓ | 4 |
+| keychaincredential.used_by |  |  |  |  |
+
 ### NetworkService — `network.general` (1 methods)
 
 | API Method | Implemented | Go Method | Tested | Tests |
@@ -376,7 +392,7 @@ Total API methods: 771 | Implemented: 74 (9.6%) | Tested: 74 (100.0% of implemen
 | virt.instance.stop | ✓ | StopInstance | ✓ | 3 |
 | virt.instance.update | ✓ | UpdateInstance | ✓ | 3 |
 
-## Uncovered Namespaces (95 namespaces, 512 methods)
+## Uncovered Namespaces (94 namespaces, 502 methods)
 
 | Namespace | Methods |
 |-----------|--------:|
@@ -432,7 +448,6 @@ Total API methods: 771 | Implemented: 74 (9.6%) | Tested: 74 (100.0% of implemen
 | kerberos | 2 |
 | kerberos.keytab | 5 |
 | kerberos.realm | 5 |
-| keychaincredential | 10 |
 | kmip | 5 |
 | ldap | 4 |
 | mail | 4 |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,9 +15,9 @@ Total API methods: 771 | Implemented: 78 (10.1%) | Tested: 78 (100.0% of impleme
 | DockerService | docker | 8 | 2 (25%) | 2 (100%) |
 | FilesystemService | filesystem | 13 | 2 (15%) | 2 (100%) |
 | InterfaceService | interface | 23 | 1 (4%) | 1 (100%) |
-| SSHService | keychaincredential | 10 | 4 (40%) | 4 (100%) |
 | NetworkService | network.general | 1 | 1 (100%) | 1 (100%) |
 | ReportingService | reporting | 8 | 2 (25%) | 2 (100%) |
+| SSHService | keychaincredential | 10 | 4 (40%) | 4 (100%) |
 | SnapshotService | zfs.snapshot | 9 | 7 (78%) | 7 (100%) |
 | SystemService | system | 14 | 2 (14%) | 2 (100%) |
 | VMService | vm, vm.device | 51 | 10 (20%) | 10 (100%) |
@@ -236,21 +236,6 @@ Total API methods: 771 | Implemented: 78 (10.1%) | Tested: 78 (100.0% of impleme
 | interface.websocket_local_ip |  |  |  |  |
 | interface.xmit_hash_policy_choices |  |  |  |  |
 
-### SSHService — `keychaincredential` (10 methods)
-
-| API Method | Implemented | Go Method | Tested | Tests |
-|------------|:-----------:|-----------|:------:|------:|
-| keychaincredential.create | ✓ | CreateSSHKeyPair, CreateSSHConnection | ✓ | 6 |
-| keychaincredential.delete | ✓ | DeleteSSHKeyPair, DeleteSSHConnection | ✓ | 4 |
-| keychaincredential.generate_ssh_key_pair |  |  |  |  |
-| keychaincredential.get_instance |  |  |  |  |
-| keychaincredential.query | ✓ | GetSSHKeyPair, ListSSHKeyPairs, GetSSHConnection, ListSSHConnections | ✓ | 16 |
-| keychaincredential.remote_ssh_host_key_scan |  |  |  |  |
-| keychaincredential.remote_ssh_semiautomatic_setup |  |  |  |  |
-| keychaincredential.setup_ssh_connection |  |  |  |  |
-| keychaincredential.update | ✓ | UpdateSSHKeyPair, UpdateSSHConnection | ✓ | 4 |
-| keychaincredential.used_by |  |  |  |  |
-
 ### NetworkService — `network.general` (1 methods)
 
 | API Method | Implemented | Go Method | Tested | Tests |
@@ -269,6 +254,21 @@ Total API methods: 771 | Implemented: 78 (10.1%) | Tested: 78 (100.0% of impleme
 | reporting.netdata_graph |  |  |  |  |
 | reporting.netdata_graphs | ✓ | ListGraphs | ✓ | 4 |
 | reporting.update |  |  |  |  |
+
+### SSHService — `keychaincredential` (10 methods)
+
+| API Method | Implemented | Go Method | Tested | Tests |
+|------------|:-----------:|-----------|:------:|------:|
+| keychaincredential.create | ✓ | CreateSSHKeyPair, CreateSSHConnection | ✓ | 6 |
+| keychaincredential.delete | ✓ | DeleteSSHKeyPair, DeleteSSHConnection | ✓ | 4 |
+| keychaincredential.generate_ssh_key_pair |  |  |  |  |
+| keychaincredential.get_instance |  |  |  |  |
+| keychaincredential.query | ✓ | GetSSHKeyPair, ListSSHKeyPairs, GetSSHConnection, ListSSHConnections | ✓ | 16 |
+| keychaincredential.remote_ssh_host_key_scan |  |  |  |  |
+| keychaincredential.remote_ssh_semiautomatic_setup |  |  |  |  |
+| keychaincredential.setup_ssh_connection |  |  |  |  |
+| keychaincredential.update | ✓ | UpdateSSHKeyPair, UpdateSSHConnection | ✓ | 4 |
+| keychaincredential.used_by |  |  |  |  |
 
 ### SnapshotService — `zfs.snapshot` (9 methods)
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Without a fallback, these operations return `client.ErrUnsupportedOperation`.
 | Filesystem | `FilesystemServiceAPI` | `NewFilesystemService(FileCaller, Version)` |
 | VMs | `VMServiceAPI` | `NewVMService(AsyncCaller, Version)` |
 | Virt (Containers) | `VirtServiceAPI` | `NewVirtService(AsyncCaller, Version)` |
+| SSH | `SSHServiceAPI` | `NewSSHService(AsyncCaller, Version)` |
 
 For the full per-method breakdown of which API endpoints are implemented and tested, see the [Feature Matrix](FEATURES.md). The library currently targets the latest stable release, **TrueNAS 25.04**.
 

--- a/keychaincredential.go
+++ b/keychaincredential.go
@@ -1,0 +1,97 @@
+package truenas
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const KeychainCredentialTypeSSHKeyPair = "SSH_KEY_PAIR"
+const KeychainCredentialTypeSSHConnection = "SSH_CREDENTIALS"
+
+// keychainCredentialRaw is the intermediate struct for parsing API responses.
+type keychainCredentialRaw struct {
+	ID         int64           `json:"id"`
+	Name       string          `json:"name"`
+	Type       string          `json:"type"`
+	Attributes json.RawMessage `json:"attributes"`
+}
+
+// SSHKeyPairResponse represents a SSH keypair from the API.
+type SSHKeyPairResponse struct {
+	ID         int64
+	Name       string
+	PrivateKey string `json:"private_key"`
+	PublicKey  string `json:"public_key"`
+}
+
+// SSHConnectionResponse represents a SSH credential from the API.
+type SSHConnectionResponse struct {
+	ID             int64
+	Name           string
+	Host           string `json:"host"`
+	Port           int32  `json:"port"`
+	Username       string `json:"username"`
+	PrivateKeyID   int64  `json:"private_key"`
+	RemoteHostKey  string `json:"remote_host_key"`
+	ConnectTimeout int32  `json:"connect_timeout,omitempty"`
+}
+
+func ParseSSHKeyPairs(data []byte) ([]SSHKeyPairResponse, error) {
+	var raws []keychainCredentialRaw
+	if err := json.Unmarshal(data, &raws); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	results := make([]SSHKeyPairResponse, 0, len(raws))
+	for _, raw := range raws {
+		cred, err := parseSSHKeyPair(raw)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, cred)
+	}
+	return results, nil
+}
+
+func parseSSHKeyPair(raw keychainCredentialRaw) (SSHKeyPairResponse, error) {
+	var c SSHKeyPairResponse
+	c.ID = raw.ID
+	c.Name = raw.Name
+
+	if len(raw.Attributes) > 0 {
+		if err := json.Unmarshal(raw.Attributes, &c); err != nil {
+			return c, fmt.Errorf("parse attributes: %w", err)
+		}
+	}
+	return c, nil
+}
+
+func ParseSSHConnections(data []byte) ([]SSHConnectionResponse, error) {
+	var raws []keychainCredentialRaw
+	if err := json.Unmarshal(data, &raws); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	results := make([]SSHConnectionResponse, 0, len(raws))
+	for _, raw := range raws {
+		cred, err := parseSSHConnection(raw)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, cred)
+	}
+	return results, nil
+}
+
+func parseSSHConnection(raw keychainCredentialRaw) (SSHConnectionResponse, error) {
+	var c SSHConnectionResponse
+	c.ID = raw.ID
+	c.Name = raw.Name
+
+	if len(raw.Attributes) > 0 {
+		if err := json.Unmarshal(raw.Attributes, &c); err != nil {
+			return c, fmt.Errorf("parse attributes: %w", err)
+		}
+	}
+	return c, nil
+}

--- a/keychaincredential_service.go
+++ b/keychaincredential_service.go
@@ -1,0 +1,282 @@
+package truenas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// SSHKeyPair is the user-facing representation of a TrueNAS ssh keypair.
+type SSHKeyPair struct {
+	ID         int64
+	Name       string
+	PrivateKey string
+	PublicKey  string
+}
+
+// CreateSSHKeyPairOpts contains options for creating a ssh keypair.
+type CreateSSHKeyPairOpts struct {
+	Name       string
+	PublicKey  string
+	PrivateKey string
+}
+
+// UpdateSSHKeyPairOpts contains options for updating a ssh keypair.
+type UpdateSSHKeyPairOpts = CreateSSHKeyPairOpts
+
+// SSHConnection is the user-facing representation of a TrueNAS ssh credential.
+type SSHConnection struct {
+	ID             int64
+	Name           string
+	Host           string
+	Port           int32
+	Username       string
+	PrivateKeyID   int64
+	RemoteHostKey  string
+	ConnectTimeout int32
+}
+
+// CreateSSHConnectionOpts contains options for creating an ssh keypair.
+type CreateSSHConnectionOpts struct {
+	Name           string
+	Host           string
+	Port           int32
+	Username       string
+	PrivateKeyID   int64
+	RemoteHostKey  string
+	ConnectTimeout int32
+}
+
+// UpdateSSHConnectionOpts contains options for updating an ssh credential.
+type UpdateSSHConnectionOpts = CreateSSHConnectionOpts
+
+// SSHService provides typed methods for the keychaincredential API namespaces.
+type SSHService struct {
+	client  Caller
+	version Version
+}
+
+// NewSSHService creates a new SSHService.
+func NewSSHService(c Caller, v Version) *SSHService {
+	return &SSHService{client: c, version: v}
+}
+
+// CreateSSHKeyPair creates an ssh keypair and returns the full object.
+func (s *SSHService) CreateSSHKeyPair(ctx context.Context, opts CreateSSHKeyPairOpts) (*SSHKeyPair, error) {
+	params := sshKeyPairOptsToParams(opts, true)
+
+	result, err := s.client.Call(ctx, "keychaincredential.create", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var createResp struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(result, &createResp); err != nil {
+		return nil, fmt.Errorf("parse create response: %w", err)
+	}
+
+	return s.GetSSHKeyPair(ctx, createResp.ID)
+}
+
+// GetSSHKeyPair returns a SSH keypair by ID, or nil if not found.
+func (s *SSHService) GetSSHKeyPair(ctx context.Context, id int64) (*SSHKeyPair, error) {
+	filter := [][]any{{"id", "=", id}}
+	result, err := s.client.Call(ctx, "keychaincredential.query", filter)
+	if err != nil {
+		return nil, err
+	}
+
+	keyPairs, err := ParseSSHKeyPairs(result)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keyPairs) == 0 {
+		return nil, nil
+	}
+
+	keyPair := sshKeyPairFromResponse(keyPairs[0])
+	return &keyPair, nil
+}
+
+// ListSSHKeyPairs returns all keychain credentials.
+func (s *SSHService) ListSSHKeyPairs(ctx context.Context) ([]SSHKeyPair, error) {
+	filter := [][]any{{"type", "=", KeychainCredentialTypeSSHKeyPair}}
+	result, err := s.client.Call(ctx, "keychaincredential.query", filter)
+	if err != nil {
+		return nil, err
+	}
+
+	keyPairs, err := ParseSSHKeyPairs(result)
+	if err != nil {
+		return nil, err
+	}
+
+	sshKeyPairs := make([]SSHKeyPair, len(keyPairs))
+	for i, resp := range keyPairs {
+		sshKeyPairs[i] = sshKeyPairFromResponse(resp)
+	}
+	return sshKeyPairs, nil
+}
+
+// UpdateSSHKeyPair updates a SSH keypair and returns the full object.
+func (s *SSHService) UpdateSSHKeyPair(ctx context.Context, id int64, opts UpdateSSHKeyPairOpts) (*SSHKeyPair, error) {
+	params := sshKeyPairOptsToParams(opts, false)
+
+	_, err := s.client.Call(ctx, "keychaincredential.update", []any{id, params})
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetSSHKeyPair(ctx, id)
+}
+
+// DeleteSSHKeyPair deletes a SSH keypair by ID.
+func (s *SSHService) DeleteSSHKeyPair(ctx context.Context, id int64) error {
+	_, err := s.client.Call(ctx, "keychaincredential.delete", id)
+	return err
+}
+
+// CreateSSHConnection creates an ssh credential and returns the full object.
+func (s *SSHService) CreateSSHConnection(ctx context.Context, opts CreateSSHConnectionOpts) (*SSHConnection, error) {
+	params := sshConnectionOptsToParams(opts, true)
+
+	result, err := s.client.Call(ctx, "keychaincredential.create", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var createResp struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(result, &createResp); err != nil {
+		return nil, fmt.Errorf("parse create response: %w", err)
+	}
+
+	return s.GetSSHConnection(ctx, createResp.ID)
+}
+
+// GetSSHConnection returns a SSH credential by ID, or nil if not found.
+func (s *SSHService) GetSSHConnection(ctx context.Context, id int64) (*SSHConnection, error) {
+	filter := [][]any{{"id", "=", id}}
+	result, err := s.client.Call(ctx, "keychaincredential.query", filter)
+	if err != nil {
+		return nil, err
+	}
+
+	credentials, err := ParseSSHConnections(result)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(credentials) == 0 {
+		return nil, nil
+	}
+
+	credential := sshConnectionFromResponse(credentials[0])
+	return &credential, nil
+}
+
+// ListSSHConnections returns all keychain credentials.
+func (s *SSHService) ListSSHConnections(ctx context.Context) ([]SSHConnection, error) {
+	filter := [][]any{{"type", "=", KeychainCredentialTypeSSHConnection}}
+	result, err := s.client.Call(ctx, "keychaincredential.query", filter)
+	if err != nil {
+		return nil, err
+	}
+
+	credentials, err := ParseSSHConnections(result)
+	if err != nil {
+		return nil, err
+	}
+
+	sshConnections := make([]SSHConnection, len(credentials))
+	for i, resp := range credentials {
+		sshConnections[i] = sshConnectionFromResponse(resp)
+	}
+	return sshConnections, nil
+}
+
+// UpdateSSHConnection updates a SSH credential and returns the full object.
+func (s *SSHService) UpdateSSHConnection(ctx context.Context, id int64, opts UpdateSSHConnectionOpts) (*SSHConnection, error) {
+	params := sshConnectionOptsToParams(opts, false)
+
+	_, err := s.client.Call(ctx, "keychaincredential.update", []any{id, params})
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetSSHConnection(ctx, id)
+}
+
+// DeleteSSHConnection deletes a SSH credential by ID.
+func (s *SSHService) DeleteSSHConnection(ctx context.Context, id int64) error {
+	_, err := s.client.Call(ctx, "keychaincredential.delete", id)
+	return err
+}
+
+// sshKeyPairOptsToParams converts CreateSSHKeyPairOpts to API parameters.
+func sshKeyPairOptsToParams(opts CreateSSHKeyPairOpts, includeType bool) map[string]any {
+	attrs := map[string]any{
+		"public_key":  opts.PublicKey,
+		"private_key": opts.PrivateKey,
+	}
+	params := map[string]any{
+		"name":       opts.Name,
+		"attributes": attrs,
+	}
+
+	if includeType {
+		params["type"] = KeychainCredentialTypeSSHKeyPair
+	}
+
+	return params
+}
+
+// sshKeyPairFromResponse converts a wire-format SSHKeyPairResponse to a user-facing SSHKeyPair.
+func sshKeyPairFromResponse(resp SSHKeyPairResponse) SSHKeyPair {
+	return SSHKeyPair{
+		ID:         resp.ID,
+		Name:       resp.Name,
+		PrivateKey: resp.PrivateKey,
+		PublicKey:  resp.PublicKey,
+	}
+}
+
+// sshConnectionOptsToParams converts CreateSSHConnectionOpts to API parameters.
+func sshConnectionOptsToParams(opts CreateSSHConnectionOpts, includeType bool) map[string]any {
+	attrs := map[string]any{
+		"host":            opts.Host,
+		"port":            opts.Port,
+		"username":        opts.Username,
+		"private_key":     opts.PrivateKeyID,
+		"remote_host_key": opts.RemoteHostKey,
+		"connect_timeout": opts.ConnectTimeout,
+	}
+	params := map[string]any{
+		"name":       opts.Name,
+		"attributes": attrs,
+	}
+
+	if includeType {
+		params["type"] = KeychainCredentialTypeSSHConnection
+	}
+
+	return params
+}
+
+// sshConnectionFromResponse converts a wire-format SSHConnectionResponse to a user-facing SSHConnection.
+func sshConnectionFromResponse(resp SSHConnectionResponse) SSHConnection {
+	return SSHConnection{
+		ID:             resp.ID,
+		Name:           resp.Name,
+		Host:           resp.Host,
+		Port:           resp.Port,
+		Username:       resp.Username,
+		PrivateKeyID:   resp.PrivateKeyID,
+		RemoteHostKey:  resp.RemoteHostKey,
+		ConnectTimeout: resp.ConnectTimeout,
+	}
+}

--- a/keychaincredential_service_iface.go
+++ b/keychaincredential_service_iface.go
@@ -1,0 +1,107 @@
+package truenas
+
+import "context"
+
+// SSHServiceAPI defines the interface for cloud sync credential and task operations.
+type SSHServiceAPI interface {
+	CreateSSHKeyPair(ctx context.Context, opts CreateSSHKeyPairOpts) (*SSHKeyPair, error)
+	GetSSHKeyPair(ctx context.Context, id int64) (*SSHKeyPair, error)
+	ListSSHKeyPairs(ctx context.Context) ([]SSHKeyPair, error)
+	UpdateSSHKeyPair(ctx context.Context, id int64, opts UpdateSSHKeyPairOpts) (*SSHKeyPair, error)
+	DeleteSSHKeyPair(ctx context.Context, id int64) error
+
+	CreateSSHConnection(ctx context.Context, opts CreateSSHConnectionOpts) (*SSHConnection, error)
+	GetSSHConnection(ctx context.Context, id int64) (*SSHConnection, error)
+	ListSSHConnections(ctx context.Context) ([]SSHConnection, error)
+	UpdateSSHConnection(ctx context.Context, id int64, opts UpdateSSHConnectionOpts) (*SSHConnection, error)
+	DeleteSSHConnection(ctx context.Context, id int64) error
+}
+
+// Compile-time checks.
+var _ SSHServiceAPI = (*SSHService)(nil)
+var _ SSHServiceAPI = (*MockSSHService)(nil)
+
+// MockSSHService is a test double for SSHServiceAPI.
+type MockSSHService struct {
+	CreateSSHKeyPairFunc func(ctx context.Context, opts CreateSSHKeyPairOpts) (*SSHKeyPair, error)
+	GetSSHKeyPairFunc    func(ctx context.Context, id int64) (*SSHKeyPair, error)
+	ListSSHKeyPairsFunc  func(ctx context.Context) ([]SSHKeyPair, error)
+	UpdateSSHKeyPairFunc func(ctx context.Context, id int64, opts UpdateSSHKeyPairOpts) (*SSHKeyPair, error)
+	DeleteSSHKeyPairFunc func(ctx context.Context, id int64) error
+
+	CreateSSHConnectionFunc func(ctx context.Context, opts CreateSSHConnectionOpts) (*SSHConnection, error)
+	GetSSHConnectionFunc    func(ctx context.Context, id int64) (*SSHConnection, error)
+	ListSSHConnectionsFunc  func(ctx context.Context) ([]SSHConnection, error)
+	UpdateSSHConnectionFunc func(ctx context.Context, id int64, opts UpdateSSHConnectionOpts) (*SSHConnection, error)
+	DeleteSSHConnectionFunc func(ctx context.Context, id int64) error
+}
+
+func (m *MockSSHService) CreateSSHKeyPair(ctx context.Context, opts CreateSSHKeyPairOpts) (*SSHKeyPair, error) {
+	if m.CreateSSHKeyPairFunc != nil {
+		return m.CreateSSHKeyPairFunc(ctx, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockSSHService) GetSSHKeyPair(ctx context.Context, id int64) (*SSHKeyPair, error) {
+	if m.GetSSHKeyPairFunc != nil {
+		return m.GetSSHKeyPairFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *MockSSHService) ListSSHKeyPairs(ctx context.Context) ([]SSHKeyPair, error) {
+	if m.ListSSHKeyPairsFunc != nil {
+		return m.ListSSHKeyPairsFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *MockSSHService) UpdateSSHKeyPair(ctx context.Context, id int64, opts UpdateSSHKeyPairOpts) (*SSHKeyPair, error) {
+	if m.UpdateSSHKeyPairFunc != nil {
+		return m.UpdateSSHKeyPairFunc(ctx, id, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockSSHService) DeleteSSHKeyPair(ctx context.Context, id int64) error {
+	if m.DeleteSSHKeyPairFunc != nil {
+		return m.DeleteSSHKeyPairFunc(ctx, id)
+	}
+	return nil
+}
+
+func (m *MockSSHService) CreateSSHConnection(ctx context.Context, opts CreateSSHConnectionOpts) (*SSHConnection, error) {
+	if m.CreateSSHConnectionFunc != nil {
+		return m.CreateSSHConnectionFunc(ctx, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockSSHService) GetSSHConnection(ctx context.Context, id int64) (*SSHConnection, error) {
+	if m.GetSSHConnectionFunc != nil {
+		return m.GetSSHConnectionFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *MockSSHService) ListSSHConnections(ctx context.Context) ([]SSHConnection, error) {
+	if m.ListSSHConnectionsFunc != nil {
+		return m.ListSSHConnectionsFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *MockSSHService) UpdateSSHConnection(ctx context.Context, id int64, opts UpdateSSHConnectionOpts) (*SSHConnection, error) {
+	if m.UpdateSSHConnectionFunc != nil {
+		return m.UpdateSSHConnectionFunc(ctx, id, opts)
+	}
+	return nil, nil
+}
+
+func (m *MockSSHService) DeleteSSHConnection(ctx context.Context, id int64) error {
+	if m.DeleteSSHConnectionFunc != nil {
+		return m.DeleteSSHConnectionFunc(ctx, id)
+	}
+	return nil
+}

--- a/keychaincredential_service_iface_test.go
+++ b/keychaincredential_service_iface_test.go
@@ -1,0 +1,45 @@
+package truenas
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMockSSHService_ImplementsInterface(t *testing.T) {
+	var _ SSHServiceAPI = (*SSHService)(nil)
+	var _ SSHServiceAPI = (*MockSSHService)(nil)
+}
+
+func TestMockSSHService_DefaultsToNil(t *testing.T) {
+	mock := &MockSSHService{}
+	ctx := context.Background()
+
+	cred, err := mock.GetSSHKeyPair(ctx, 1)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if cred != nil {
+		t.Fatalf("expected nil result, got: %v", cred)
+	}
+}
+
+func TestMockSSHService_CallsFunc(t *testing.T) {
+	called := false
+	mock := &MockSSHService{
+		GetSSHKeyPairFunc: func(ctx context.Context, id int64) (*SSHKeyPair, error) {
+			called = true
+			return &SSHKeyPair{ID: id}, nil
+		},
+	}
+
+	cred, err := mock.GetSSHKeyPair(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected GetSSHKeyPairFunc to be called")
+	}
+	if cred.ID != 42 {
+		t.Fatalf("expected ID 42, got %d", cred.ID)
+	}
+}

--- a/keychaincredential_service_test.go
+++ b/keychaincredential_service_test.go
@@ -1,0 +1,851 @@
+package truenas
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestSSHService_CreateSSHKeyPair(t *testing.T) {
+	callCount := 0
+	testData := sampleSSHKeyPair()
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				callCount++
+				if callCount == 1 {
+					if method != "keychaincredential.create" {
+						t.Errorf("expected method keychaincredential.create, got %s", method)
+					}
+					p := params.(map[string]any)
+					if p["name"] != testData.Name {
+						t.Errorf("expected name '%s', got '%s'", testData.Name, p["name"])
+					}
+					if p["type"] != KeychainCredentialTypeSSHKeyPair {
+						t.Errorf("expected type '%s', got '%s'", KeychainCredentialTypeSSHKeyPair, p["type"])
+					}
+					if _, ok := p["attributes"]; !ok {
+						t.Error("expected attributes in params")
+					} else {
+						attrs := p["attributes"].(map[string]interface{})
+						if attrs["public_key"] != testData.PublicKey {
+							t.Errorf("expected attrs.public_key '%s', got '%s'", testData.PublicKey, p["public_key"])
+						}
+						if attrs["private_key"] != testData.PrivateKey {
+							t.Errorf("expected attrs.private_key '%s', got '%s'", testData.PrivateKey, p["private_key"])
+						}
+					}
+
+					return json.RawMessage(`{"id": 1}`), nil
+				}
+				return sampleSSHKeyPairJSON(), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshKeyPair, err := svc.CreateSSHKeyPair(context.Background(), CreateSSHKeyPairOpts{
+		Name:       testData.Name,
+		PublicKey:  testData.PublicKey,
+		PrivateKey: testData.PrivateKey,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sshKeyPair == nil {
+		t.Fatal("expected non-nil sshkeypair")
+	}
+	if sshKeyPair.ID != 1 {
+		t.Errorf("expected ID %d, got %d", testData.ID, sshKeyPair.ID)
+	}
+	if sshKeyPair.Name != "ssh keypair name" {
+		t.Errorf("expected name '%s', got '%s'", testData.Name, sshKeyPair.Name)
+	}
+	if sshKeyPair.PublicKey != "public key" {
+		t.Errorf("expected publickey '%s', got '%s'", testData.PublicKey, sshKeyPair.PublicKey)
+	}
+	if sshKeyPair.PrivateKey != "private key" {
+		t.Errorf("expected privatekey '%s', got '%s'", testData.PrivateKey, sshKeyPair.PrivateKey)
+	}
+}
+
+func TestSSHService_CreateSSHKeyPair_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("connection refused")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshKeyPair, err := svc.CreateSSHKeyPair(context.Background(), CreateSSHKeyPairOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if sshKeyPair != nil {
+		t.Error("expected nil sshkeypair on error")
+	}
+}
+
+func TestSSHService_CreateSSHKeyPair_ParseError(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`not json`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.CreateSSHKeyPair(context.Background(), CreateSSHKeyPairOpts{})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSSHService_GetSSHKeyPair(t *testing.T) {
+	testData := sampleSSHKeyPair()
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				if method != "keychaincredential.query" {
+					t.Errorf("expected method keychaincredential.query, got %s", method)
+				}
+				return sampleSSHKeyPairJSON(), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshKeyPair, err := svc.GetSSHKeyPair(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sshKeyPair == nil {
+		t.Fatal("expected non-nil sshKeyPair")
+	}
+	if sshKeyPair.ID != testData.ID {
+		t.Errorf("expected ID %d, got %d", testData.ID, sshKeyPair.ID)
+	}
+	if sshKeyPair.Name != testData.Name {
+		t.Errorf("expected name '%s', got '%s'", testData.Name, sshKeyPair.Name)
+	}
+	if sshKeyPair.PublicKey != testData.PublicKey {
+		t.Errorf("expected publickey '%s', got '%s'", testData.PublicKey, sshKeyPair.PublicKey)
+	}
+	if sshKeyPair.PrivateKey != testData.PrivateKey {
+		t.Errorf("expected privatekey '%s', got '%s'", testData.PrivateKey, sshKeyPair.PrivateKey)
+	}
+}
+
+func TestSSHService_GetSSHKeyPair_NotFound(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`[]`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshKeyPair, err := svc.GetSSHKeyPair(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sshKeyPair != nil {
+		t.Error("expected nil sshkeypair for not found")
+	}
+}
+
+func TestSSHService_GetSSHKeyPair_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("timeout")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.GetSSHKeyPair(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSSHService_GetSSHKeyPair_ParseError(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`not json`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.GetSSHKeyPair(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSSHService_ListSSHKeyPairs(t *testing.T) {
+	testData := sampleSSHKeyPairs()
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				if method != "keychaincredential.query" {
+					t.Errorf("expected method keychaincredential.query, got %s", method)
+				}
+				if params == nil {
+					t.Error("expected filter params for ListSSHKeyPairs")
+				}
+				return json.RawMessage(sampleSSHKeyPairsJSON()), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshKeyPairs, err := svc.ListSSHKeyPairs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sshKeyPairs) != 2 {
+		t.Fatalf("expected 2 sshKeyPairs, got %d", len(sshKeyPairs))
+	}
+
+	if sshKeyPairs[0].ID != testData[0].ID {
+		t.Errorf("expected ID[0] %d, got %d", testData[0].ID, sshKeyPairs[0].ID)
+	}
+	if sshKeyPairs[0].Name != testData[0].Name {
+		t.Errorf("expected name[0] '%s', got '%s'", testData[0].Name, sshKeyPairs[0].Name)
+	}
+	if sshKeyPairs[0].PublicKey != testData[0].PublicKey {
+		t.Errorf("expected publickey[0] '%s', got '%s'", testData[0].PublicKey, sshKeyPairs[0].PublicKey)
+	}
+	if sshKeyPairs[0].PrivateKey != testData[0].PrivateKey {
+		t.Errorf("expected privatekey[0] '%s', got '%s'", testData[0].PrivateKey, sshKeyPairs[0].PrivateKey)
+	}
+
+	if sshKeyPairs[1].ID != testData[1].ID {
+		t.Errorf("expected ID[1] %d, got %d", testData[1].ID, sshKeyPairs[1].ID)
+	}
+	if sshKeyPairs[1].Name != testData[1].Name {
+		t.Errorf("expected name[1] '%s', got '%s'", testData[1].Name, sshKeyPairs[1].Name)
+	}
+	if sshKeyPairs[1].PublicKey != testData[1].PublicKey {
+		t.Errorf("expected publickey[1] '%s', got '%s'", testData[1].PublicKey, sshKeyPairs[1].PublicKey)
+	}
+	if sshKeyPairs[1].PrivateKey != testData[1].PrivateKey {
+		t.Errorf("expected privatekey[1] '%s', got '%s'", testData[1].PrivateKey, sshKeyPairs[1].PrivateKey)
+	}
+}
+
+func TestSSHService_ListSSHKeyPairs_Empty(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`[]`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshKeyPairs, err := svc.ListSSHKeyPairs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sshKeyPairs) != 0 {
+		t.Errorf("expected 0 sshkeypairs, got %d", len(sshKeyPairs))
+	}
+}
+
+func TestSSHService_ListSSHKeyPairs_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("network error")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.ListSSHKeyPairs(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSSHService_ListSSHKeyPairs_ParseError(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`not json`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.ListSSHKeyPairs(context.Background())
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSSHService_UpdateSSHKeyPair(t *testing.T) {
+	callCount := 0
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				callCount++
+				if callCount == 1 {
+					if method != "keychaincredential.update" {
+						t.Errorf("expected method keychaincredential.update, got %s", method)
+					}
+					slice, ok := params.([]any)
+					if !ok {
+						t.Fatal("expected []any params for update")
+					}
+					if len(slice) != 2 {
+						t.Fatalf("expected 2 elements, got %d", len(slice))
+					}
+					id, ok := slice[0].(int64)
+					if !ok || id != 1 {
+						t.Errorf("expected id 1, got %v", slice[0])
+					}
+					p := slice[1].(map[string]any)
+					if p["name"] != "Updated keypair" {
+						t.Errorf("expected name 'Updated keypair', got %v", p["name"])
+					}
+					return json.RawMessage(`{"id": 1}`), nil
+				}
+				return sampleSSHKeyPairJSON(), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshKeyPair, err := svc.UpdateSSHKeyPair(context.Background(), 1, UpdateSSHKeyPairOpts{
+		Name: "Updated keypair",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sshKeyPair == nil {
+		t.Fatal("expected non-nil sshkeypair")
+	}
+	if sshKeyPair.ID != 1 {
+		t.Errorf("expected ID 1, got %d", sshKeyPair.ID)
+	}
+}
+
+func TestSSHService_UpdateSSHKeyPair_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("not found")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.UpdateSSHKeyPair(context.Background(), 999, UpdateSSHKeyPairOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSSHService_DeleteSSHKeyPair(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				if method != "keychaincredential.delete" {
+					t.Errorf("expected method keychaincredential.delete, got %s", method)
+				}
+				id, ok := params.(int64)
+				if !ok || id != 5 {
+					t.Errorf("expected id 5, got %v", params)
+				}
+				return nil, nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	err := svc.DeleteSSHKeyPair(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSSHService_DeleteSSHKeyPair_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("permission denied")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	err := svc.DeleteSSHKeyPair(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSSHService_CreateSSHConnection(t *testing.T) {
+	callCount := 0
+	testData := sampleSSHConnection()
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				callCount++
+				if callCount == 1 {
+					if method != "keychaincredential.create" {
+						t.Errorf("expected method keychaincredential.create, got %s", method)
+					}
+					p := params.(map[string]any)
+					if p["name"] != testData.Name {
+						t.Errorf("expected name '%s', got '%s'", testData.Name, p["name"])
+					}
+					if p["type"] != KeychainCredentialTypeSSHConnection {
+						t.Errorf("expected type '%s', got '%s'", KeychainCredentialTypeSSHConnection, p["type"])
+					}
+
+					if _, ok := p["attributes"]; !ok {
+						t.Error("expected attributes in params")
+					} else {
+						attrs := p["attributes"].(map[string]interface{})
+						if attrs["host"] != testData.Host {
+							t.Errorf("expected host '%s', got '%s'", testData.Host, p["host"])
+						}
+						if attrs["port"] != testData.Port {
+							t.Errorf("expected port '%d', got '%d'", testData.Port, p["port"])
+						}
+						if attrs["username"] != testData.Username {
+							t.Errorf("expected username '%s', got '%s'", testData.Username, p["username"])
+						}
+						if attrs["private_key"] != testData.PrivateKeyID {
+							t.Errorf("expected private_key '%d', got '%d'", testData.PrivateKeyID, p["private_key"])
+						}
+						if attrs["remote_host_key"] != testData.RemoteHostKey {
+							t.Errorf("expected remote_host_key '%s', got '%s'", testData.RemoteHostKey, p["remote_host_key"])
+						}
+						if attrs["connect_timeout"] != testData.ConnectTimeout {
+							t.Errorf("expected connect_timeout '%d', got '%d'", testData.ConnectTimeout, p["connect_timeout"])
+						}
+					}
+
+					return json.RawMessage(`{"id": 1}`), nil
+				}
+				return sampleSSHConnectionJSON(), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshConnection, err := svc.CreateSSHConnection(context.Background(), CreateSSHConnectionOpts{
+		Name:           testData.Name,
+		Host:           testData.Host,
+		Port:           testData.Port,
+		Username:       testData.Username,
+		PrivateKeyID:   testData.PrivateKeyID,
+		RemoteHostKey:  testData.RemoteHostKey,
+		ConnectTimeout: testData.ConnectTimeout,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sshConnection == nil {
+		t.Fatal("expected non-nil sshconnection")
+	}
+	if sshConnection.ID != 1 {
+		t.Errorf("expected ID %d, got %d", testData.ID, sshConnection.ID)
+	}
+	if sshConnection.Name != testData.Name {
+		t.Errorf("expected name '%s', got '%s'", testData.Name, sshConnection.Name)
+	}
+	if sshConnection.Host != testData.Host {
+		t.Errorf("expected host '%s', got %s", testData.Host, sshConnection.Host)
+	}
+	if sshConnection.Port != testData.Port {
+		t.Errorf("expected port '%d', got %d", testData.Port, sshConnection.Port)
+	}
+	if sshConnection.Username != testData.Username {
+		t.Errorf("expected username '%s', got %s", testData.Username, sshConnection.Username)
+	}
+	if sshConnection.PrivateKeyID != testData.PrivateKeyID {
+		t.Errorf("expected private_key '%d', got %d", testData.PrivateKeyID, sshConnection.PrivateKeyID)
+	}
+	if sshConnection.RemoteHostKey != testData.RemoteHostKey {
+		t.Errorf("expected remote_host_key '%s', got %s", testData.RemoteHostKey, sshConnection.RemoteHostKey)
+	}
+	if sshConnection.ConnectTimeout != testData.ConnectTimeout {
+		t.Errorf("expected connect_timeout '%d', got %d", testData.ConnectTimeout, sshConnection.ConnectTimeout)
+	}
+}
+
+func TestSSHService_CreateSSHConnection_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("connection refused")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshConnection, err := svc.CreateSSHConnection(context.Background(), CreateSSHConnectionOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if sshConnection != nil {
+		t.Error("expected nil sshkeypair on error")
+	}
+}
+
+func TestSSHService_CreateSSHConnection_ParseError(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`not json`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.CreateSSHConnection(context.Background(), CreateSSHConnectionOpts{})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSSHService_GetSSHConnection(t *testing.T) {
+	testData := sampleSSHConnection()
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				if method != "keychaincredential.query" {
+					t.Errorf("expected method keychaincredential.query, got %s", method)
+				}
+				return sampleSSHConnectionJSON(), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshConnection, err := svc.GetSSHConnection(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sshConnection == nil {
+		t.Fatal("expected non-nil sshConnection")
+	}
+	if sshConnection.ID != testData.ID {
+		t.Errorf("expected ID %d, got %d", testData.ID, sshConnection.ID)
+	}
+	if sshConnection.Name != testData.Name {
+		t.Errorf("expected name '%s', got '%s'", testData.Name, sshConnection.Name)
+	}
+	if sshConnection.Host != testData.Host {
+		t.Errorf("expected host '%s', got %s", testData.Host, sshConnection.Host)
+	}
+	if sshConnection.Port != testData.Port {
+		t.Errorf("expected port '%d', got %d", testData.Port, sshConnection.Port)
+	}
+	if sshConnection.Username != testData.Username {
+		t.Errorf("expected username '%s', got %s", testData.Username, sshConnection.Username)
+	}
+	if sshConnection.PrivateKeyID != testData.PrivateKeyID {
+		t.Errorf("expected private_key '%d', got %d", testData.PrivateKeyID, sshConnection.PrivateKeyID)
+	}
+	if sshConnection.RemoteHostKey != testData.RemoteHostKey {
+		t.Errorf("expected remote_host_key '%s', got %s", testData.RemoteHostKey, sshConnection.RemoteHostKey)
+	}
+	if sshConnection.ConnectTimeout != testData.ConnectTimeout {
+		t.Errorf("expected connect_timeout '%d', got %d", testData.ConnectTimeout, sshConnection.ConnectTimeout)
+	}
+}
+
+func TestSSHService_GetSSHConnection_NotFound(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`[]`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshConnection, err := svc.GetSSHConnection(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sshConnection != nil {
+		t.Error("expected nil sshkeypair for not found")
+	}
+}
+
+func TestSSHService_GetSSHConnection_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("timeout")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.GetSSHConnection(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSSHService_GetSSHConnection_ParseError(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`not json`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.GetSSHConnection(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSSHService_ListSSHConnections(t *testing.T) {
+	testData := sampleSSHConnections()
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				if method != "keychaincredential.query" {
+					t.Errorf("expected method keychaincredential.query, got %s", method)
+				}
+				if params == nil {
+					t.Error("expected filter params for ListSSHConnections")
+				}
+				return json.RawMessage(sampleSSHConnectionsJSON()), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshConnections, err := svc.ListSSHConnections(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sshConnections) != 2 {
+		t.Fatalf("expected 2 sshConnections, got %d", len(sshConnections))
+	}
+
+	if sshConnections[0].ID != testData[0].ID {
+		t.Errorf("expected ID[0] %d, got %d", testData[0].ID, sshConnections[0].ID)
+	}
+	if sshConnections[0].Name != testData[0].Name {
+		t.Errorf("expected name[0] '%s', got '%s'", testData[0].Name, sshConnections[0].Name)
+	}
+	if sshConnections[0].Host != testData[0].Host {
+		t.Errorf("expected host '%s', got %s", testData[0].Host, sshConnections[0].Host)
+	}
+	if sshConnections[0].Port != testData[0].Port {
+		t.Errorf("expected port '%d', got %d", testData[0].Port, sshConnections[0].Port)
+	}
+	if sshConnections[0].Username != testData[0].Username {
+		t.Errorf("expected username '%s', got %s", testData[0].Username, sshConnections[0].Username)
+	}
+	if sshConnections[0].PrivateKeyID != testData[0].PrivateKeyID {
+		t.Errorf("expected private_key '%d', got %d", testData[0].PrivateKeyID, sshConnections[0].PrivateKeyID)
+	}
+	if sshConnections[0].RemoteHostKey != testData[0].RemoteHostKey {
+		t.Errorf("expected remote_host_key '%s', got %s", testData[0].RemoteHostKey, sshConnections[0].RemoteHostKey)
+	}
+	if sshConnections[0].ConnectTimeout != testData[0].ConnectTimeout {
+		t.Errorf("expected connect_timeout '%d', got %d", testData[0].ConnectTimeout, sshConnections[0].ConnectTimeout)
+	}
+
+	if sshConnections[1].ID != testData[1].ID {
+		t.Errorf("expected ID[1] %d, got %d", testData[1].ID, sshConnections[1].ID)
+	}
+	if sshConnections[1].Name != testData[1].Name {
+		t.Errorf("expected name[1] '%s', got '%s'", testData[1].Name, sshConnections[1].Name)
+	}
+	if sshConnections[1].Host != testData[1].Host {
+		t.Errorf("expected host '%s', got %s", testData[1].Host, sshConnections[1].Host)
+	}
+	if sshConnections[1].Port != testData[1].Port {
+		t.Errorf("expected port '%d', got %d", testData[1].Port, sshConnections[1].Port)
+	}
+	if sshConnections[1].Username != testData[1].Username {
+		t.Errorf("expected username '%s', got %s", testData[1].Username, sshConnections[1].Username)
+	}
+	if sshConnections[1].PrivateKeyID != testData[1].PrivateKeyID {
+		t.Errorf("expected private_key '%d', got %d", testData[1].PrivateKeyID, sshConnections[1].PrivateKeyID)
+	}
+	if sshConnections[1].RemoteHostKey != testData[1].RemoteHostKey {
+		t.Errorf("expected remote_host_key '%s', got %s", testData[1].RemoteHostKey, sshConnections[1].RemoteHostKey)
+	}
+	if sshConnections[1].ConnectTimeout != testData[1].ConnectTimeout {
+		t.Errorf("expected connect_timeout '%d', got %d", testData[1].ConnectTimeout, sshConnections[1].ConnectTimeout)
+	}
+}
+
+func TestSSHService_ListSSHConnections_Empty(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`[]`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshConnections, err := svc.ListSSHConnections(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sshConnections) != 0 {
+		t.Errorf("expected 0 sshkeypairs, got %d", len(sshConnections))
+	}
+}
+
+func TestSSHService_ListSSHConnections_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("network error")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.ListSSHConnections(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSSHService_ListSSHConnections_ParseError(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return json.RawMessage(`not json`), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.ListSSHConnections(context.Background())
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSSHService_UpdateSSHConnection(t *testing.T) {
+	callCount := 0
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				callCount++
+				if callCount == 1 {
+					if method != "keychaincredential.update" {
+						t.Errorf("expected method keychaincredential.update, got %s", method)
+					}
+					slice, ok := params.([]any)
+					if !ok {
+						t.Fatal("expected []any params for update")
+					}
+					if len(slice) != 2 {
+						t.Fatalf("expected 2 elements, got %d", len(slice))
+					}
+					id, ok := slice[0].(int64)
+					if !ok || id != 1 {
+						t.Errorf("expected id 1, got %v", slice[0])
+					}
+					p := slice[1].(map[string]any)
+					if p["name"] != "Updated keypair" {
+						t.Errorf("expected name 'Updated keypair', got %v", p["name"])
+					}
+					return json.RawMessage(`{"id": 1}`), nil
+				}
+				return sampleSSHConnectionJSON(), nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	sshConnection, err := svc.UpdateSSHConnection(context.Background(), 1, UpdateSSHConnectionOpts{
+		Name: "Updated keypair",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sshConnection == nil {
+		t.Fatal("expected non-nil sshkeypair")
+	}
+	if sshConnection.ID != 1 {
+		t.Errorf("expected ID 1, got %d", sshConnection.ID)
+	}
+}
+
+func TestSSHService_UpdateSSHConnection_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("not found")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	_, err := svc.UpdateSSHConnection(context.Background(), 999, UpdateSSHConnectionOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSSHService_DeleteSSHConnection(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				if method != "keychaincredential.delete" {
+					t.Errorf("expected method keychaincredential.delete, got %s", method)
+				}
+				id, ok := params.(int64)
+				if !ok || id != 5 {
+					t.Errorf("expected id 5, got %v", params)
+				}
+				return nil, nil
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	err := svc.DeleteSSHConnection(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSSHService_DeleteSSHConnection_Error(t *testing.T) {
+	mock := &mockAsyncCaller{
+		mockCaller: mockCaller{
+			callFunc: func(ctx context.Context, method string, params any) (json.RawMessage, error) {
+				return nil, errors.New("permission denied")
+			},
+		},
+	}
+
+	svc := NewSSHService(mock, Version{Major: 25, Minor: 4})
+	err := svc.DeleteSSHConnection(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/keychaincredential_service_testdata_test.go
+++ b/keychaincredential_service_testdata_test.go
@@ -1,0 +1,173 @@
+package truenas
+
+import "encoding/json"
+
+// sampleSSHKeyPairAttributesJSON returns an ssh keypair attributes structure as json
+func sampleSSHKeyPairAttributesJSON() json.RawMessage {
+	return json.RawMessage(`{
+		"public_key": "public key",
+		"private_key": "private key"
+	}`)
+}
+
+// sampleSSHKeyPairJSON returns a single ssh keypair JSON response in an array.
+func sampleSSHKeyPairJSON() json.RawMessage {
+	return json.RawMessage(`[{
+		"id": 1,
+		"name": "ssh keypair name",
+		"attributes" : {
+			"public_key": "public key",
+			"private_key": "private key"
+        }
+	}]`)
+}
+
+// sampleSSHKeyPairJSON returns two ssh keypair JSON responses in an array.
+func sampleSSHKeyPairsJSON() json.RawMessage {
+	return json.RawMessage(`[
+		{
+			"id": 1,
+			"name": "ssh keypair name 1",
+			"type" : "SSH_KEY_PAIR",
+			"attributes" : {
+				"public_key": "public key 1",
+				"private_key": "private key 1"
+			}
+		},
+		{
+			"id": 2,
+			"name": "ssh keypair name 2",
+			"type" : "SSH_KEY_PAIR",
+			"attributes" : {
+				"public_key": "public key 2",
+				"private_key": "private key 2"
+			}
+		}
+	]`)
+}
+
+// sampleSSHKeyPair returns a single SSHKeyPair.
+func sampleSSHKeyPair() SSHKeyPair {
+	return SSHKeyPair{
+		ID:         1,
+		Name:       "ssh keypair name",
+		PublicKey:  "public key",
+		PrivateKey: "private key",
+	}
+}
+
+// sampleSSHKeyPair returns an array with two single SSHKeyPairs.
+func sampleSSHKeyPairs() []SSHKeyPair {
+	return []SSHKeyPair{
+		{
+			ID:         1,
+			Name:       "ssh keypair name 1",
+			PublicKey:  "public key 1",
+			PrivateKey: "private key 1",
+		},
+		{
+			ID:         2,
+			Name:       "ssh keypair name 2",
+			PublicKey:  "public key 2",
+			PrivateKey: "private key 2",
+		},
+	}
+}
+
+// sampleSSHConnectionAttributesJSON returns an ssh credential attributes structure as json
+func sampleSSHConnectionAttributesJSON() json.RawMessage {
+	return json.RawMessage(`{
+		"host": "some host", 
+		"port": 123, 
+		"username": "some username", 
+		"remote_host_key": "some remote host key", 
+		"connect_timeout": 42, 
+		"private_key": 1
+	}`)
+}
+
+// sampleSSHConnectionJSON returns a single ssh credential JSON response in an array.
+func sampleSSHConnectionJSON() json.RawMessage {
+	return json.RawMessage(`[{
+		"id": 1,
+		"name": "ssh credential name",
+		"attributes" : {
+			"host": "some host",
+			"port": 123,
+			"username": "some username",
+			"remote_host_key": "some remote host key",
+			"connect_timeout": 42,
+			"private_key": 1
+        }
+	}]`)
+}
+
+// sampleSSHConnectionJSON returns two ssh credential JSON responses in an array.
+func sampleSSHConnectionsJSON() json.RawMessage {
+	return json.RawMessage(`[
+		{
+			"id": 1,
+			"name": "ssh credential name 1",
+			"attributes" : {
+				"host": "some host 1",
+				"port": 123,
+				"username": "some username 1",
+				"remote_host_key": "some remote host key 1",
+				"connect_timeout": 42,
+				"private_key": 1
+			}
+		},
+		{
+			"id": 2,
+			"name": "ssh credential name 2",
+			"attributes" : {
+				"host": "some host 2",
+				"port": 456,
+				"username": "some username 2",
+				"remote_host_key": "some remote host key 2",
+				"connect_timeout": 37,
+				"private_key": 2
+			}
+		}
+	]`)
+}
+
+// sampleSSHConnection returns a single SSHConnection.
+func sampleSSHConnection() SSHConnection {
+	return SSHConnection{
+		ID:             1,
+		Name:           "ssh credential name",
+		Host:           "some host",
+		Port:           123,
+		Username:       "some username",
+		PrivateKeyID:   1,
+		RemoteHostKey:  "some remote host key",
+		ConnectTimeout: 42,
+	}
+}
+
+// sampleSSHConnections returns an array with two SSHConnections.
+func sampleSSHConnections() []SSHConnection {
+	return []SSHConnection{
+		{
+			ID:             1,
+			Name:           "ssh credential name 1",
+			Host:           "some host 1",
+			Port:           123,
+			Username:       "some username 1",
+			PrivateKeyID:   1,
+			RemoteHostKey:  "some remote host key 1",
+			ConnectTimeout: 42,
+		},
+		{
+			ID:             2,
+			Name:           "ssh credential name 2",
+			Host:           "some host 2",
+			Port:           456,
+			Username:       "some username 2",
+			PrivateKeyID:   2,
+			RemoteHostKey:  "some remote host key 2",
+			ConnectTimeout: 37,
+		},
+	}
+}

--- a/keychaincredential_test.go
+++ b/keychaincredential_test.go
@@ -1,0 +1,350 @@
+package truenas
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func Test_ParseSSHKeyPair(t *testing.T) {
+	testData := sampleSSHKeyPair()
+	tests := []struct {
+		name    string
+		raw     keychainCredentialRaw
+		want    SSHKeyPairResponse
+		wantErr bool
+	}{
+		{
+			name: "parses valid credential json",
+			raw: keychainCredentialRaw{
+				ID:         testData.ID,
+				Name:       testData.Name,
+				Type:       KeychainCredentialTypeSSHKeyPair,
+				Attributes: json.RawMessage(sampleSSHKeyPairAttributesJSON()),
+			},
+			want: SSHKeyPairResponse{
+				ID:         testData.ID,
+				Name:       testData.Name,
+				PublicKey:  testData.PublicKey,
+				PrivateKey: testData.PrivateKey,
+			},
+		},
+		{
+			name: "invalid JSON in provider",
+			raw: keychainCredentialRaw{
+				ID:         2,
+				Name:       "Invalid keypair",
+				Type:       KeychainCredentialTypeSSHKeyPair,
+				Attributes: json.RawMessage(`{not valid json`),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSSHKeyPair(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSSHKeyPair() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.ID != tt.want.ID {
+				t.Errorf("ID = %v, want %v", got.ID, tt.want.ID)
+			}
+			if got.Name != tt.want.Name {
+				t.Errorf("Name = %v, want %v", got.Name, tt.want.Name)
+			}
+			if got.PrivateKey != tt.want.PrivateKey {
+				t.Errorf("PrivateKey = %v, want %v", got.PrivateKey, tt.want.PrivateKey)
+			}
+			if got.PublicKey != tt.want.PublicKey {
+				t.Errorf("PublicKey = %v, want %v", got.PublicKey, tt.want.PublicKey)
+			}
+		})
+	}
+}
+
+func Test_ParseSSHKeyPairs(t *testing.T) {
+	testData := sampleSSHKeyPair()
+	testDatas := sampleSSHKeyPairs()
+	tests := []struct {
+		name    string
+		data    []byte
+		want    []SSHKeyPairResponse
+		wantErr bool
+	}{
+		{
+			name: "Single keypair",
+			data: []byte(sampleSSHKeyPairJSON()),
+			want: []SSHKeyPairResponse{
+				{
+					ID:         testData.ID,
+					Name:       testData.Name,
+					PublicKey:  testData.PublicKey,
+					PrivateKey: testData.PrivateKey,
+				},
+			},
+		},
+		{
+			name: "Multiple keypairs",
+			data: []byte(sampleSSHKeyPairsJSON()),
+			want: []SSHKeyPairResponse{
+				{
+					ID:         testDatas[0].ID,
+					Name:       testDatas[0].Name,
+					PublicKey:  testDatas[0].PublicKey,
+					PrivateKey: testDatas[0].PrivateKey,
+				},
+				{
+					ID:         testDatas[1].ID,
+					Name:       testDatas[1].Name,
+					PublicKey:  testDatas[1].PublicKey,
+					PrivateKey: testDatas[1].PrivateKey,
+				},
+			},
+		},
+		{
+			name:    "invalid JSON array",
+			data:    []byte(`{not valid json`),
+			wantErr: true,
+		},
+		{
+			name: "invalid attributes JSON",
+			data: []byte(`[{
+				"id": 1,
+				"name": "Invalid",
+				"attributes": {invalid json}
+			}]`),
+			wantErr: true,
+		},
+		{
+			name: "empty array",
+			data: []byte(`[]`),
+			want: []SSHKeyPairResponse{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSSHKeyPairs(tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseSSHKeyPairs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseSSHKeyPairs() returned %d SSHKeyPairs, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i].ID != tt.want[i].ID {
+					t.Errorf("SSHKeyPair[%d].ID = %v, want %v", i, got[i].ID, tt.want[i].ID)
+				}
+				if got[i].Name != tt.want[i].Name {
+					t.Errorf("SSHKeyPair[%d].Name = %v, want %v", i, got[i].Name, tt.want[i].Name)
+				}
+				if got[i].PublicKey != tt.want[i].PublicKey {
+					t.Errorf("SSHKeyPair[%d].PublicKey = %v, want %v", i, got[i].PublicKey, tt.want[i].PublicKey)
+				}
+				if got[i].PrivateKey != tt.want[i].PrivateKey {
+					t.Errorf("SSHKeyPair[%d].PrivateKey = %v, want %v", i, got[i].PrivateKey, tt.want[i].PrivateKey)
+				}
+			}
+		})
+	}
+}
+
+func Test_ParseSSHConnection(t *testing.T) {
+	testData := sampleSSHConnection()
+	tests := []struct {
+		name    string
+		raw     keychainCredentialRaw
+		want    SSHConnectionResponse
+		wantErr bool
+	}{
+		{
+			name: "parses valid credential json",
+			raw: keychainCredentialRaw{
+				ID:         testData.ID,
+				Name:       testData.Name,
+				Type:       KeychainCredentialTypeSSHConnection,
+				Attributes: json.RawMessage(sampleSSHConnectionAttributesJSON()),
+			},
+			want: SSHConnectionResponse{
+				ID:             testData.ID,
+				Name:           testData.Name,
+				Host:           testData.Host,
+				Port:           testData.Port,
+				Username:       testData.Username,
+				PrivateKeyID:   testData.PrivateKeyID,
+				RemoteHostKey:  testData.RemoteHostKey,
+				ConnectTimeout: testData.ConnectTimeout,
+			},
+		},
+		{
+			name: "invalid JSON in provider",
+			raw: keychainCredentialRaw{
+				ID:         2,
+				Name:       "Invalid credential",
+				Type:       KeychainCredentialTypeSSHConnection,
+				Attributes: json.RawMessage(`{not valid json`),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSSHConnection(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSSHConnection() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.ID != tt.want.ID {
+				t.Errorf("ID = %v, want %v", got.ID, tt.want.ID)
+			}
+			if got.Name != tt.want.Name {
+				t.Errorf("Name = %v, want %v", got.Name, tt.want.Name)
+			}
+			if got.Host != tt.want.Host {
+				t.Errorf("Host = %v, want %v", got.Host, tt.want.Host)
+			}
+			if got.Port != tt.want.Port {
+				t.Errorf("Port = %v, want %v", got.Port, tt.want.Port)
+			}
+			if got.Username != tt.want.Username {
+				t.Errorf("Username = %v, want %v", got.Username, tt.want.Username)
+			}
+			if got.PrivateKeyID != tt.want.PrivateKeyID {
+				t.Errorf("PrivateKeyID = %v, want %v", got.PrivateKeyID, tt.want.PrivateKeyID)
+			}
+			if got.RemoteHostKey != tt.want.RemoteHostKey {
+				t.Errorf("RemoteHostKey = %v, want %v", got.RemoteHostKey, tt.want.RemoteHostKey)
+			}
+			if got.ConnectTimeout != tt.want.ConnectTimeout {
+				t.Errorf("ConnectTimeout = %v, want %v", got.ConnectTimeout, tt.want.ConnectTimeout)
+			}
+		})
+	}
+}
+
+func Test_ParseSSHConnections(t *testing.T) {
+	testData := sampleSSHConnection()
+	testDatas := sampleSSHConnections()
+	tests := []struct {
+		name    string
+		data    []byte
+		want    []SSHConnectionResponse
+		wantErr bool
+	}{
+		{
+			name: "Single credential",
+			data: []byte(sampleSSHConnectionJSON()),
+			want: []SSHConnectionResponse{
+				{
+					ID:             testData.ID,
+					Name:           testData.Name,
+					Host:           testData.Host,
+					Port:           testData.Port,
+					Username:       testData.Username,
+					PrivateKeyID:   testData.PrivateKeyID,
+					RemoteHostKey:  testData.RemoteHostKey,
+					ConnectTimeout: testData.ConnectTimeout,
+				},
+			},
+		},
+		{
+			name: "Multiple credentials",
+			data: []byte(sampleSSHConnectionsJSON()),
+			want: []SSHConnectionResponse{
+				{
+					ID:             testDatas[0].ID,
+					Name:           testDatas[0].Name,
+					Host:           testDatas[0].Host,
+					Port:           testDatas[0].Port,
+					Username:       testDatas[0].Username,
+					PrivateKeyID:   testDatas[0].PrivateKeyID,
+					RemoteHostKey:  testDatas[0].RemoteHostKey,
+					ConnectTimeout: testDatas[0].ConnectTimeout,
+				},
+				{
+					ID:             testDatas[1].ID,
+					Name:           testDatas[1].Name,
+					Host:           testDatas[1].Host,
+					Port:           testDatas[1].Port,
+					Username:       testDatas[1].Username,
+					PrivateKeyID:   testDatas[1].PrivateKeyID,
+					RemoteHostKey:  testDatas[1].RemoteHostKey,
+					ConnectTimeout: testDatas[1].ConnectTimeout,
+				},
+			},
+		},
+		{
+			name:    "invalid JSON array",
+			data:    []byte(`{not valid json`),
+			wantErr: true,
+		},
+		{
+			name: "invalid attributes JSON",
+			data: []byte(`[{
+				"id": 1,
+				"name": "Invalid",
+				"attributes": {invalid json}
+			}]`),
+			wantErr: true,
+		},
+		{
+			name: "empty array",
+			data: []byte(`[]`),
+			want: []SSHConnectionResponse{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSSHConnections(tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseSSHConnections() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseSSHConnections() returned %d SSHConnections, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i].ID != tt.want[i].ID {
+					t.Errorf("SSHConnection[%d].ID = %v, want %v", i, got[i].ID, tt.want[i].ID)
+				}
+				if got[i].Name != tt.want[i].Name {
+					t.Errorf("SSHConnection[%d].Name = %v, want %v", i, got[i].Name, tt.want[i].Name)
+				}
+				if got[i].Host != tt.want[i].Host {
+					t.Errorf("SSHConnection[%d].Host = %v, want %v", i, got[i].Host, tt.want[i].Host)
+				}
+				if got[i].Port != tt.want[i].Port {
+					t.Errorf("SSHConnection[%d].Port = %v, want %v", i, got[i].Port, tt.want[i].Port)
+				}
+				if got[i].Username != tt.want[i].Username {
+					t.Errorf("SSHConnection[%d].Username = %v, want %v", i, got[i].Username, tt.want[i].Username)
+				}
+				if got[i].PrivateKeyID != tt.want[i].PrivateKeyID {
+					t.Errorf("SSHConnection[%d].PrivateKeyID = %v, want %v", i, got[i].PrivateKeyID, tt.want[i].PrivateKeyID)
+				}
+				if got[i].RemoteHostKey != tt.want[i].RemoteHostKey {
+					t.Errorf("SSHConnection[%d].RemoteHostKey = %v, want %v", i, got[i].RemoteHostKey, tt.want[i].RemoteHostKey)
+				}
+				if got[i].ConnectTimeout != tt.want[i].ConnectTimeout {
+					t.Errorf("SSHConnection[%d].ConnectTimeout = %v, want %v", i, got[i].ConnectTimeout, tt.want[i].ConnectTimeout)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds apis to the truenas-go library for reading/writing SSH keypairs and SSH connections. These are the names used in the Truenas UI. The underlying api namespace used for both types is named 'keychaincredential'. Each keychaincredential resource has a 'type' property which indicates whether the resource is a keypair or a connection. An 'attributes' property contains the type-specific properties. For both types an attribute named 'private_key' is used. For keypairs it represents the private-key portion (string) of an SSH keypair. For connections it represents an id (number) pointing to another keypair resource. I initially tried to use 1 set of methods/types for both resource types, but ran into problems with json serialization caused by the ambiguous private_key attribute type. I ended up creating dedicated api methods/types for both resource types. I admin that this results in a bit of code duplication, which you might not agree with so I'm curious what you think. Because of this I set the PR to draft status, if you prefer a different design I'll refactor and submit a new PR.