### PR TITLE
add dataset recordsize

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -12,6 +12,7 @@ type DatasetResponse struct {
 	Quota        SizePropertyField `json:"quota"`
 	RefQuota     SizePropertyField `json:"refquota"`
 	Atime        PropertyValue     `json:"atime"`
+	Recordsize   PropertyValue     `json:"recordsize"`
 	Volsize      SizePropertyField `json:"volsize"`
 	Volblocksize PropertyValue     `json:"volblocksize"`
 	Sparse       PropertyValue     `json:"sparse"`

--- a/dataset_service.go
+++ b/dataset_service.go
@@ -17,6 +17,7 @@ type Dataset struct {
 	Quota       int64
 	RefQuota    int64
 	Atime       string
+	Recordsize  string
 	Used        int64
 	Available   int64
 }
@@ -29,6 +30,7 @@ type CreateDatasetOpts struct {
 	Quota       int64
 	RefQuota    int64
 	Atime       string
+	Recordsize  string
 }
 
 // UpdateDatasetOpts contains options for updating a filesystem dataset.
@@ -39,6 +41,7 @@ type UpdateDatasetOpts struct {
 	Quota       *int64
 	RefQuota    *int64
 	Atime       string // Empty = don't change
+	Recordsize  string // Empty = don't change
 	Comments    *string
 }
 
@@ -278,6 +281,7 @@ func datasetFromResponse(resp DatasetResponse) Dataset {
 		Quota:       resp.Quota.Parsed,
 		RefQuota:    resp.RefQuota.Parsed,
 		Atime:       resp.Atime.Value,
+		Recordsize:  resp.Recordsize.Value,
 		Used:        resp.Used.Parsed,
 		Available:   resp.Available.Parsed,
 	}

--- a/dataset_service.go
+++ b/dataset_service.go
@@ -335,6 +335,9 @@ func datasetCreateParams(opts CreateDatasetOpts) map[string]any {
 	if opts.Atime != "" {
 		params["atime"] = opts.Atime
 	}
+	if opts.Recordsize != "" {
+		params["recordsize"] = opts.Recordsize
+	}
 	return params
 }
 
@@ -352,6 +355,9 @@ func datasetUpdateParams(opts UpdateDatasetOpts) map[string]any {
 	}
 	if opts.Atime != "" {
 		params["atime"] = opts.Atime
+	}
+	if opts.Recordsize != "" {
+		params["recordsize"] = opts.Recordsize
 	}
 	if opts.Comments != nil {
 		params["comments"] = *opts.Comments

--- a/dataset_service_conversion_test.go
+++ b/dataset_service_conversion_test.go
@@ -14,6 +14,7 @@ func TestDatasetFromResponse(t *testing.T) {
 		Quota:       SizePropertyField{Parsed: 2147483648, Value: "2G"},
 		RefQuota:    SizePropertyField{Parsed: 1073741824, Value: "1G"},
 		Atime:       PropertyValue{Value: "off"},
+		Recordsize:  PropertyValue{Value: "1M"},
 	}
 
 	ds := datasetFromResponse(resp)
@@ -44,6 +45,9 @@ func TestDatasetFromResponse(t *testing.T) {
 	}
 	if ds.Atime != "off" {
 		t.Errorf("expected Atime off, got %s", ds.Atime)
+	}
+	if ds.Recordsize != "1M" {
+		t.Errorf("expected Recordsize 1M, got %s", ds.Recordsize)
 	}
 }
 
@@ -136,6 +140,7 @@ func TestDatasetCreateParams(t *testing.T) {
 		Quota:       1073741824,
 		RefQuota:    536870912,
 		Atime:       "on",
+		Recordsize:  "1M",
 	}
 
 	params := datasetCreateParams(opts)
@@ -160,6 +165,9 @@ func TestDatasetCreateParams(t *testing.T) {
 	}
 	if params["atime"] != "on" {
 		t.Errorf("expected atime on, got %v", params["atime"])
+	}
+	if params["recordsize"] != "1M" {
+		t.Errorf("expected recordsize 1M, got %v", params["recordsize"])
 	}
 }
 
@@ -191,6 +199,9 @@ func TestDatasetCreateParams_Minimal(t *testing.T) {
 	if _, ok := params["atime"]; ok {
 		t.Error("expected no atime key")
 	}
+	if _, ok := params["recordsize"]; ok {
+		t.Error("expected no recordsize key")
+	}
 }
 
 func TestDatasetUpdateParams(t *testing.T) {
@@ -199,6 +210,7 @@ func TestDatasetUpdateParams(t *testing.T) {
 		Quota:       Int64Ptr(2147483648),
 		RefQuota:    Int64Ptr(1073741824),
 		Atime:       "off",
+		Recordsize:  "1M",
 		Comments:    StringPtr("updated"),
 	}
 
@@ -215,6 +227,9 @@ func TestDatasetUpdateParams(t *testing.T) {
 	}
 	if params["atime"] != "off" {
 		t.Errorf("expected atime off, got %v", params["atime"])
+	}
+	if params["recordsize"] != "1M" {
+		t.Errorf("expected recordsize 1M, got %v", params["recordsize"])
 	}
 	if params["comments"] != "updated" {
 		t.Errorf("expected comments updated, got %v", params["comments"])
@@ -256,6 +271,21 @@ func TestDatasetUpdateParams_CompressionAndAtime(t *testing.T) {
 	}
 	if len(params) != 2 {
 		t.Errorf("expected 2 params, got %d", len(params))
+	}
+}
+
+func TestDatasetUpdateParams_Recordsize(t *testing.T) {
+	opts := UpdateDatasetOpts{
+		Recordsize: "1M",
+	}
+
+	params := datasetUpdateParams(opts)
+
+	if params["recordsize"] != "1M" {
+		t.Errorf("expected recordsize 1M, got %v", params["recordsize"])
+	}
+	if len(params) != 1 {
+		t.Errorf("expected 1 param, got %d", len(params))
 	}
 }
 


### PR DESCRIPTION
Exposes the `recordsize` ZFS property on filesystem datasets so callers can read it from `Dataset` and set it via `CreateDatasetOpts` / `UpdateDatasetOpts`. The TrueNAS middleware API already accepts `recordsize` on `pool.dataset.create` / `pool.dataset.update`, but the Go client did not surface it.

   ## Changes

   Mirrors the existing `Compression` / `Atime` pattern — additive only, no signature changes:

   - `DatasetResponse`: add `Recordsize PropertyValue` (`recordsize` JSON key)
   - `Dataset`: add `Recordsize string`
   - `CreateDatasetOpts`: add `Recordsize string`
   - `UpdateDatasetOpts`: add `Recordsize string` (empty = don't change)
   - `datasetFromResponse`: map `resp.Recordsize.Value`
   - `datasetCreateParams` / `datasetUpdateParams`: send `recordsize` when non-empty, omit otherwise (consistent with other optional string fields)
   - Tests: cover parsing, create (full + minimal), and update (full + recordsize-only)

   ## Notes

   - No new API methods — `recordsize` is a property on already-implemented endpoints, so the feature matrix is unaffected.
   - `recordsize` is a stable ZFS property; no version-aware method resolution needed.
   - Backwards compatible: all new fields are optional / zero-valued.