### PR TITLE
feat: add SSH agent auth and configurable sudo (rebase of #13)

### DIFF
--- a/client/ssh.go
+++ b/client/ssh.go
@@ -222,6 +222,8 @@ func (c *SSHClient) connect() error {
 		if err != nil {
 			return fmt.Errorf("failed to connect to SSH agent at %q: %w", c.config.AgentSocket, err)
 		}
+		// close after handshake; Signers only needed during Dial below
+		defer func() { _ = conn.Close() }()
 		agentClient := agent.NewClient(conn)
 		authMethods = append(authMethods, ssh.PublicKeysCallback(agentClient.Signers))
 	} else {


### PR DESCRIPTION
## Summary

Rebase of #13 onto current `main` (was conflicting after dataset recordsize and other merges).

Same change set as #13 / closes the SDK side of terraform-provider-truenas#5:

- `UseAgent` + `AgentSocket` (falls back to `SSH_AUTH_SOCK`)
- `NoSudo` to skip the `sudo` prefix on midclt
- `UseAgent` and `PrivateKey` mutually exclusive
- tests for validation + sudo prefix behavior

## Relation to #13

Prefer this branch over #13 if the original still has conflicts. Happy to close this if you rebase #13 yourself instead.

## Test plan

- [x] `go test ./client -run 'Agent|NoSudo|SudoPrefix|PrivateKeyRequired'`
- [x] `go test` on root/api/client packages
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSH-agent authentication with configurable agent socket selection, including support for `SSH_AUTH_SOCK`.
  * Added an option to execute SSH commands without `sudo`.
  * Improved SSH configuration validation for authentication settings and required sockets or keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->